### PR TITLE
cleaner version of /{optionalTopLevelResource}/events/* endpoints

### DIFF
--- a/REST Bindings/openapi.json
+++ b/REST Bindings/openapi.json
@@ -340,7 +340,7 @@
         }
       }
     },
-    "/{optionalTopLevelResource}/events": {
+    "/events": {
       "parameters": [
         {
           "in": "query",
@@ -349,16 +349,6 @@
           "schema": {
             "type": "integer",
             "default": 30
-          }
-        },
-        {
-          "in": "path",
-          "name": "optionalTopLevelResource",
-          "description": "An optional top-level resource to access events.",
-          "required": true,
-          "schema": {
-            "type": "string",
-            "pattern": "^((epcs|bizSteps|bizLocations|readPoints|dispositions)\\/([^/\\n\\r]+))?$"
           }
         }
       ],
@@ -477,7 +467,157 @@
         }
       }
     },
-    "/{optionalTopLevelResource}/events/{eventType}": {
+    "/events/{topLevelResourceKey}/{topLevelResourceValue}": {
+      "parameters": [
+        {
+          "in": "query",
+          "name": "perPage",
+          "description": "Parameter to control pagination. perPage specifies the maximum number of events returned in one batch.",
+          "schema": {
+            "type": "integer",
+            "default": 30
+          }
+        },
+        {
+          "name": "topLevelResourceKey",
+          "in": "path",
+          "description": "Parameter to recognise top level resource key which",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "enum": [
+              "epcs",
+              "bizSteps",
+              "bizLocations",
+              "readPoints",
+              "dispositions"
+            ]
+          }
+        },
+        {
+          "name": "topLevelResourceValue",
+          "in": "path",
+          "description": "Parameter for top level resource value by events should be filtered",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "options": {
+        "summary": "Query supported EPCIS version and related vocabularies/standards.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/GS1-EPCIS-version"
+          },
+          {
+            "$ref": "#/components/parameters/GS1-EPCIS-min"
+          },
+          {
+            "$ref": "#/components/parameters/GS1-EPCIS-max"
+          },
+          {
+            "$ref": "#/components/parameters/GS1-CBV-version"
+          },
+          {
+            "$ref": "#/components/parameters/GS1-EPCIS-extensions"
+          },
+          {
+            "$ref": "#/components/parameters/GS1-CBV-extensions"
+          },
+          {
+            "$ref": "#/components/parameters/GS1-Vendor-version"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Server can comply with the GS1-EPCIS-related requirements from the client.",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Server can comply with the GS1-EPCIS-related requirements from the client",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "401": {
+            "description": "Authorization information is missing or invalid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "properties": {
+                        "status": {
+                          "type": "integer",
+                          "enum": [
+                            401
+                          ],
+                          "default": 401
+                        },
+                        "type": {
+                          "type": "string",
+                          "format": "uri",
+                          "enum": [
+                            "epcisExceptions:SecurityException"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "$ref": "#/components/schemas/RFC7807ProblemResponseBody"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "This is a server-side problem caused by an exception.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "properties": {
+                        "status": {
+                          "type": "integer",
+                          "enum": [
+                            500
+                          ],
+                          "default": 500
+                        },
+                        "type": {
+                          "type": "string",
+                          "format": "uri",
+                          "enum": [
+                            "epcisExceptions:ImplementationException"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "$ref": "#/components/schemas/RFC7807ProblemResponseBody"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/events/{eventType}/{topLevelResourceKey}/{topLevelResourceValue}": {
       "parameters": [
         {
           "in": "query",
@@ -504,13 +644,28 @@
           }
         },
         {
+          "name": "topLevelResourceKey",
           "in": "path",
-          "name": "optionalTopLevelResource",
-          "description": "An optional top-level resource to access events.",
+          "description": "Parameter to resolve top level resource key",
           "required": true,
           "schema": {
             "type": "string",
-            "pattern": "^((epcs|bizSteps|bizLocations|readPoints|dispositions)\\/([^/\\n\\r]+))?$"
+            "enum": [
+              "epcs",
+              "bizSteps",
+              "bizLocations",
+              "readPoints",
+              "dispositions"
+            ]
+          }
+        },
+        {
+          "name": "topLevelResourceValue",
+          "in": "path",
+          "description": "Parameter for top level resource value by events should be filtered",
+          "required": true,
+          "schema": {
+            "type": "string"
           }
         }
       ],
@@ -732,7 +887,7 @@
         }
       }
     },
-    "/{optionalTopLevelResource}/events/{eventType}/{eventID}": {
+    "/events/{eventID}": {
       "parameters": [
         {
           "in": "query",
@@ -744,30 +899,12 @@
           }
         },
         {
-          "name": "eventType",
-          "in": "path",
-          "required": true,
-          "schema": {
-            "$ref": "#/components/schemas/EPCISEventTypes"
-          }
-        },
-        {
           "name": "eventID",
           "in": "path",
           "required": true,
           "schema": {
             "type": "string",
             "format": "uuid"
-          }
-        },
-        {
-          "in": "path",
-          "name": "optionalTopLevelResource",
-          "description": "An optional top-level resource to access events.",
-          "required": true,
-          "schema": {
-            "type": "string",
-            "pattern": "^((epcs|bizSteps|bizLocations|readPoints|dispositions)\\/([^/\\n\\r]+))?$"
           }
         }
       ],

--- a/REST Bindings/openapi.yaml
+++ b/REST Bindings/openapi.yaml
@@ -194,7 +194,7 @@ paths:
                   - $ref: '#/components/schemas/RFC7807ProblemResponseBody'
 
 
-  /{optionalTopLevelResource}/events:
+  /events:
     parameters:
       - in: query
         name: perPage
@@ -202,14 +202,6 @@ paths:
         schema:
           type: integer
           default: 30
-      - in: path
-        name: optionalTopLevelResource
-        description: An optional top-level resource to access events.
-        required: true
-        schema:
-          type: string
-          pattern: ^((epcs|bizSteps|bizLocations|readPoints|dispositions)\/([^/\n\r]+))?$
-
     options:
       summary: Query supported EPCIS version and related vocabularies/standards.
       parameters:
@@ -274,7 +266,98 @@ paths:
                           - epcisExceptions:ImplementationException
                   - $ref: '#/components/schemas/RFC7807ProblemResponseBody'
 
-  /{optionalTopLevelResource}/events/{eventType}:
+
+  /events/{topLevelResourceKey}/{topLevelResourceValue}:
+    parameters:
+      - in: query
+        name: perPage
+        description: Parameter to control pagination. perPage specifies the maximum number of events returned in one batch.
+        schema:
+          type: integer
+          default: 30
+      - name: topLevelResourceKey
+        in: path
+        description: Parameter to recognise top level resource key which
+        required: true
+        schema:
+          type: string
+          enum:
+            - epcs
+            - bizSteps
+            - bizLocations
+            - readPoints
+            - dispositions
+      - name: topLevelResourceValue
+        in: path
+        description: Parameter for top level resource value by events should be filtered
+        required: true
+        schema:
+          type: string
+    options:
+      summary: Query supported EPCIS version and related vocabularies/standards.
+      parameters:
+        - $ref: '#/components/parameters/GS1-EPCIS-version'
+        - $ref: '#/components/parameters/GS1-EPCIS-min'
+        - $ref: '#/components/parameters/GS1-EPCIS-max'
+        - $ref: '#/components/parameters/GS1-CBV-version'
+        - $ref: '#/components/parameters/GS1-EPCIS-extensions'
+        - $ref: '#/components/parameters/GS1-CBV-extensions'
+        - $ref: '#/components/parameters/GS1-Vendor-version'
+      responses:
+        '200':
+          description: Server can comply with the GS1-EPCIS-related requirements from the client.
+          content:
+            application/json:
+              schema:
+                {}
+    get:
+      responses:
+        '200':
+          description: Server can comply with the GS1-EPCIS-related requirements from the client
+          content:
+            application/json:
+              schema:
+                {}
+        '401':
+          description: Authorization information is missing or invalid.
+          content:
+            application/problem+json:
+              schema:
+                allOf:
+                  - properties:
+                      status:
+                        type: integer
+                        enum:
+                          - 401
+                        default: 401
+                      type:
+                        type: string
+                        format: uri
+                        enum:
+                          - epcisExceptions:SecurityException
+                  - $ref: '#/components/schemas/RFC7807ProblemResponseBody'
+
+        '500':
+          description: This is a server-side problem caused by an exception.
+          content:
+            application/problem+json:
+              schema:
+                allOf:
+                  - properties:
+                      status:
+                        type: integer
+                        enum:
+                          - 500
+                        default: 500
+                      type:
+                        type: string
+                        format: uri
+                        enum:
+                          - epcisExceptions:ImplementationException
+                  - $ref: '#/components/schemas/RFC7807ProblemResponseBody'
+
+
+  /events/{eventType}/{topLevelResourceKey}/{topLevelResourceValue}:
     parameters:
       - in: query
         name: perPage
@@ -289,13 +372,24 @@ paths:
           oneOf:
             - $ref: '#/components/schemas/EPCISEventTypes'
             - $ref: '#/components/schemas/AllEvent'
-      - in: path
-        name: optionalTopLevelResource
-        description: An optional top-level resource to access events.
+      - name: topLevelResourceKey
+        in: path
+        description: Parameter to resolve top level resource key
         required: true
         schema:
           type: string
-          pattern: ^((epcs|bizSteps|bizLocations|readPoints|dispositions)\/([^/\n\r]+))?$
+          enum:
+            - epcs
+            - bizSteps
+            - bizLocations
+            - readPoints
+            - dispositions
+      - name: topLevelResourceValue
+        in: path
+        description: Parameter for top level resource value by events should be filtered
+        required: true
+        schema:
+          type: string
     options:
       summary: Query supported EPCIS version and related vocabularies/standards
       parameters:
@@ -419,7 +513,7 @@ paths:
                   - $ref: '#/components/schemas/RFC7807ProblemResponseBody'
 
 
-  /{optionalTopLevelResource}/events/{eventType}/{eventID}:
+  /events/{eventID}:
     parameters:
       - in: query
         name: perPage
@@ -427,25 +521,12 @@ paths:
         schema:
           type: integer
           default: 30
-      - name: eventType
-        in: path
-        required: true
-        schema:
-          $ref: '#/components/schemas/EPCISEventTypes'
       - name: eventID
         in: path
         required: true
         schema:
           type: string
           format: uuid
-      - in: path
-        name: optionalTopLevelResource
-        description: An optional top-level resource to access events.
-        required: true
-        schema:
-          type: string
-          pattern: ^((epcs|bizSteps|bizLocations|readPoints|dispositions)\/([^/\n\r]+))?$
-
 
     options:
       summary: Query supported EPCIS version and related vocabularies/standards.


### PR DESCRIPTION
Hi @mgh128 , @joelvogt,

Below are highlights of changes enclosed in this PR.

1. added `/events` endpoint to query all events with pagination support
2. Converted `/{optionalTopLevelResource}/events` to `/events/{topLevelResourceKey}/{topLevelResourceValue}`. Corrected response type of get request as well.
3. Converted `/{optionalTopLevelResource}/events/{eventType}` to `/events/{eventType}/{topLevelResourceKey}/{topLevelResourceValue}`; In my opinion, it would make more sense have eventType path parameter before others as it seems more symmetric to first think of eventType filter and then more specific filters.
4. Converted `/{optionalTopLevelResource}/events/{eventType}/{eventID}` into `/events/{eventID}`; eventID is absolute identity of any event therefore not seeing any significance of other path parameters.

Please let me know if there are any questions