### PR TITLE
Revision for some optional fields related to association event

### DIFF
--- a/XSD/EPCglobal-epcis-2_0.xsd
+++ b/XSD/EPCglobal-epcis-2_0.xsd
@@ -239,8 +239,8 @@ GS1 retains the right to make changes to this document at any time, without noti
   <!-- Since 2.0 -->
   <xsd:complexType name="PersistentDispositionType">
     <xsd:sequence>
-      <xsd:element name="unset" type="epcis:DispositionIDType" minOccurs="0"/>
-      <xsd:element name="set" type="epcis:DispositionIDType" minOccurs="0"/>
+      <xsd:element name="unset" type="epcis:DispositionIDType" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="set" type="epcis:DispositionIDType" minOccurs="0" maxOccurs="unbounded"/>
     </xsd:sequence>
   </xsd:complexType>
 

--- a/XSD/EPCglobal-epcis-2_0.xsd
+++ b/XSD/EPCglobal-epcis-2_0.xsd
@@ -197,7 +197,7 @@ GS1 retains the right to make changes to this document at any time, without noti
   <xsd:complexType name="EPCISEventListExtension2Type">
     <xsd:sequence>
       <xsd:element name="AssociationEvent" type="epcis:AssociationEventType"/>
-      <xsd:element name="extension" type="epcis:EPCISEventListExtension3Type"/>
+      <xsd:element name="extension" type="epcis:EPCISEventListExtension3Type" minOccurs="0"/>
     </xsd:sequence>
     <xsd:anyAttribute processContents="lax"/>
   </xsd:complexType>
@@ -783,7 +783,7 @@ GS1 retains the right to make changes to this document at any time, without noti
       <xsd:extension base="epcis:EPCISEventType">
         <xsd:sequence>
           <xsd:element name="parentID" type="epcis:ParentIDType" minOccurs="1"/>
-          <xsd:element name="childEPCs" type="epcis:EPCListType"/>
+          <xsd:element name="childEPCs" type="epcis:EPCListType" minOccurs="0"/>
           <xsd:element name="childQuantityList" type="epcis:QuantityListType" minOccurs="0"/>
           <xsd:element name="action" type="epcis:ActionType"/>
           <xsd:element name="bizStep" type="epcis:BusinessStepIDType" minOccurs="0"/>

--- a/XSD/EPCglobal-epcis-2_0.xsd
+++ b/XSD/EPCglobal-epcis-2_0.xsd
@@ -66,7 +66,7 @@ GS1 retains the right to make changes to this document at any time, without noti
     </xsd:sequence>
     <xsd:anyAttribute processContents="lax"/>
   </xsd:complexType>
-  
+
   <!-- Since 1.2 -->
   <xsd:complexType name="EPCISMasterDataType">
     <xsd:sequence>
@@ -234,6 +234,16 @@ GS1 retains the right to make changes to this document at any time, without noti
   <xsd:simpleType name="DispositionIDType">
     <xsd:restriction base="xsd:anyURI"/>
   </xsd:simpleType>
+
+  <!-- Standard Vocabulary -->
+  <!-- Since 2.0 -->
+  <xsd:complexType name="PersistentDispositionType">
+    <xsd:sequence>
+      <xsd:element name="unset" type="epcis:DispositionIDType" minOccurs="0"/>
+      <xsd:element name="set" type="epcis:DispositionIDType" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
   <!-- User Vocabulary -->
   <xsd:simpleType name="EPCClassType">
     <xsd:restriction base="xsd:anyURI"/>
@@ -392,7 +402,7 @@ GS1 retains the right to make changes to this document at any time, without noti
     <xsd:sequence>
       <xsd:element name="declarationTime" type="xsd:dateTime"/>
       <xsd:element name="reason" type="epcis:ErrorReasonIDType" minOccurs="0"/>
-      <xsd:element name="correctiveEventIDs" type="epcis:CorrectiveEventIDsType" minOccurs="0"/>          
+      <xsd:element name="correctiveEventIDs" type="epcis:CorrectiveEventIDsType" minOccurs="0"/>
       <xsd:element name="extension" type="epcis:ErrorDeclarationExtensionType" minOccurs="0"/>
       <xsd:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
     </xsd:sequence>
@@ -480,7 +490,7 @@ GS1 retains the right to make changes to this document at any time, without noti
 			  <xsd:attribute type="xsd:string" name="stringValue" use="optional"/>
 			  <xsd:attribute type="xsd:boolean" name="booleanValue" use="optional"/>
 			  <xsd:attribute type="xsd:hexBinary" name="hexBinaryValue" use="optional"/>
-			  <xsd:attribute type="xsd:anyURI" name="uriValue" use="optional"/>			  
+			  <xsd:attribute type="xsd:anyURI" name="uriValue" use="optional"/>
 			  <xsd:attribute type="xsd:string" name="uom" use="optional"/>
 			  <xsd:attribute type="xsd:float" name="minValue" use="optional"/>
 			  <xsd:attribute type="xsd:float" name="maxValue" use="optional"/>
@@ -571,6 +581,7 @@ GS1 retains the right to make changes to this document at any time, without noti
   <xsd:complexType name="ObjectEventExtension2Type">
     <xsd:sequence>
       <xsd:element name="sensorElementList" type="epcis:SensorElementListType" minOccurs="0"/>
+      <xsd:element name="persistentDisposition" type="epcis:PersistentDispositionType" minOccurs="0" />
       <xsd:element name="extension" type="epcis:ObjectEventExtension3Type" minOccurs="0"/>
     </xsd:sequence>
     <xsd:anyAttribute processContents="lax"/>
@@ -624,6 +635,7 @@ GS1 retains the right to make changes to this document at any time, without noti
   <xsd:complexType name="AggregationEventExtension2Type">
     <xsd:sequence>
       <xsd:element name="sensorElementList" type="epcis:SensorElementListType" minOccurs="0"/>
+      <xsd:element name="persistentDisposition" type="epcis:PersistentDispositionType" minOccurs="0" />
       <xsd:element name="extension" type="epcis:AggregationEventExtension3Type" minOccurs="0"/>
     </xsd:sequence>
     <xsd:anyAttribute processContents="lax"/>
@@ -708,6 +720,7 @@ GS1 retains the right to make changes to this document at any time, without noti
   <xsd:complexType name="TransactionEventExtension2Type">
     <xsd:sequence>
       <xsd:element name="sensorElementList" type="epcis:SensorElementListType" minOccurs="0"/>
+      <xsd:element name="persistentDisposition" type="epcis:PersistentDispositionType" minOccurs="0" />
       <xsd:element name="extension" type="epcis:TransactionEventExtension3Type" minOccurs="0"/>
     </xsd:sequence>
     <xsd:anyAttribute processContents="lax"/>
@@ -757,6 +770,7 @@ GS1 retains the right to make changes to this document at any time, without noti
   <xsd:complexType name="TransformationEventExtensionType">
     <xsd:sequence>
       <xsd:element name="sensorElementList" type="epcis:SensorElementListType" minOccurs="0"/>
+      <xsd:element name="persistentDisposition" type="epcis:PersistentDispositionType" minOccurs="0" />
       <xsd:element name="extension" type="epcis:TransformationEventExtension2Type" minOccurs="0"/>
      </xsd:sequence>
     <xsd:anyAttribute processContents="lax"/>
@@ -769,12 +783,12 @@ GS1 retains the right to make changes to this document at any time, without noti
     </xsd:sequence>
     <xsd:anyAttribute processContents="lax"/>
   </xsd:complexType>
-  
+
   <!-- Since 2.0 -->
   <xsd:complexType name="AssociationEventType">
     <xsd:annotation>
       <xsd:documentation xml:lang="en">
-      Association Event captures an event that applies to objects that 
+      Association Event captures an event that applies to objects that
       have a physical association with one another, a physical association being more
       permanent or persistent than a physical aggregation.
              </xsd:documentation>
@@ -794,6 +808,7 @@ GS1 retains the right to make changes to this document at any time, without noti
           <xsd:element name="sourceList" type="epcis:SourceListType" minOccurs="0"/>
           <xsd:element name="destinationList" type="epcis:DestinationListType" minOccurs="0"/>
           <xsd:element name="sensorElementList" type="epcis:SensorElementListType" minOccurs="0"/>
+          <xsd:element name="persistentDisposition" type="epcis:PersistentDispositionType" minOccurs="0" />
           <xsd:element name="extension" type="epcis:AssociationEventExtensionType" minOccurs="0"/>
           <xsd:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
         </xsd:sequence>
@@ -808,6 +823,6 @@ GS1 retains the right to make changes to this document at any time, without noti
     </xsd:sequence>
     <xsd:anyAttribute processContents="lax"/>
   </xsd:complexType>
-  
-  
+
+
 </xsd:schema>


### PR DESCRIPTION
In prototyping EPCIS v2.0 (XML), 
some minor issues have been found related to Association Event, thus revising and reporting them. 

**Line 200**
- EPCISEventListExtension2Type now has 'mandatory' extension field so that
  Currently, https://github.com/gs1/EPCIS/blob/master/XSD/AssociationEventDRAFTMessages.xml 
  cannot be validated against the schema. 
  To resolve the issue, all of the events should have extension field like
```xml
<extension>
	<extension>
		<AssociationEvent>
			<eventTime>2019-11-01T14:00:00.000+01:00</eventTime>
			<eventTimeZoneOffset>+01:00</eventTimeZoneOffset>
			...
			<readPoint>
				<id>urn:epc:id:sgln:4012345.00001.0</id>
			</readPoint>
		</AssociationEvent>
                <!-- Like here -->
                <extension><a/></extension>
	</extension>
</extension>
```
  But it seems unnecessary. 
   The revision on Line 200 could resolve the issue. 

**Line 786**
- It is more minor issue. Even if the line 1496 in EPCIS v2.0 draft shows that childEPCs are optional field but
  current schema cannot validate an associate event with zero childEPCs.
  For example, 
```xml
     <AssociationEvent>
             <eventTime>2019-11-01T14:00:00.000+01:00</eventTime>
                        <eventTimeZoneOffset>+01:00</eventTimeZoneOffset>
                        <parentID>urn:epc:id:grai:4012345.55555.987</parentID>
                        <action>ADD</action>
                        <!-- No child EPCs -->
                        <bizStep>urn:epcglobal:cbv:bizstep:assembling</bizStep>
                        <readPoint>
                            <id>urn:epc:id:sgln:4012345.00001.0</id>
                        </readPoint>
     </AssociationEvent>
```
  But it seems invalid against the standard definition. 
  Actually, this issue is same for aggregation event but I did not revise it due to backward-compatible issue. 
