### PR TITLE
Minor json syntax error on AssociationEvent-g,h fixed, add some examples about digital link ID usage

### DIFF
--- a/JSON/AssociationEvent/AssociationEvent-g.jsonld
+++ b/JSON/AssociationEvent/AssociationEvent-g.jsonld
@@ -54,7 +54,7 @@
 		  "isA": "AssociationEvent",
 		  "eventTime": "2019-11-04T14:00:00.000+01:00",
 		  "eventTimeZoneOffset": "+01:00",
-		  "errorDeclaration": {"declarationTime":"2019-11-07T14:00:00.000+01:00","reason":"urn:epcglobal:cbv:er:incorrect_data","correctiveEventIDs":["urn:uuid:fd338495-0e6d-41dd-afee-a862ecd32518"]}
+		  "errorDeclaration": {"declarationTime":"2019-11-07T14:00:00.000+01:00","reason":"urn:epcglobal:cbv:er:incorrect_data","correctiveEventIDs":["urn:uuid:fd338495-0e6d-41dd-afee-a862ecd32518"]},
 		  "parentID":"urn:epc:id:grai:4012345.55555.987",
 		  "action": "DELETE",
 		  "bizStep": "urn:epcglobal:cbv:bizstep:disassembling",

--- a/JSON/AssociationEvent/AssociationEvent-h.jsonld
+++ b/JSON/AssociationEvent/AssociationEvent-h.jsonld
@@ -56,7 +56,7 @@
 		  "eventTimeZoneOffset": "+01:00",
 		  "eventID": "urn:uuid:fd338495-0e6d-41dd-afee-a862ecd32518",
 		  "parentID":"urn:epc:id:grai:4012345.55555.987",
-		  "childEPCs": ["urn:epc:id:giai:4000001.12345","urn:epc:id:giai:4000001.12346"]
+		  "childEPCs": ["urn:epc:id:giai:4000001.12345","urn:epc:id:giai:4000001.12346"],
 		  "action": "DELETE",
 		  "bizStep": "urn:epcglobal:cbv:bizstep:disassembling",
 		  "readPoint": "urn:epc:id:sgln:4012345.00002.0"

--- a/JSON/Example_9.8.1-MasterData-complying-with-schema.json
+++ b/JSON/Example_9.8.1-MasterData-complying-with-schema.json
@@ -1,0 +1,133 @@
+{
+	"id": "_:example_9.8.1",
+	"isA": "EPCISDocument",
+	"schemaVersion": 2.0,
+	"creationDate": "2005-07-11T11:30:47.0Z",
+	"format": "application/ld+json",
+	"epcisHeader": {
+		"epcisMasterData": {
+			"vocabularyList": [
+				{
+					"type": "urn:epcglobal:epcis:vtype:BusinessLocation",
+					"vocabularyElementList": [
+						{
+							"isA": "VocabularyElement",
+							"id": "urn:epc:id:sgln:0037000.00729.0",
+							"attributes": [
+								{ "id": "xmda:latitude", "attribute": "+18.0000" },
+								{ "id": "xmda:longitude", "attribute": "-70.0000" },
+								{
+									"id": "xmda:address",
+									"attribute": {
+										"@context": {
+											"@vocab": "http://epcis.example.com/ns/"
+										},
+										"isA": "Address",
+										"street": "100 Nowhere Street",
+										"city": "Fancy",
+										"state": "DC",
+										"zip": "99999"
+									}
+								}
+							],
+							"children": [
+								"urn:epc:id:sgln:0037000.00729.8201",
+								"urn:epc:id:sgln:0037000.00729.8202",
+								"urn:epc:id:sgln:0037000.00729.8203"
+							]
+						},
+						{
+							"isA": "VocabularyElement",
+							"id": "urn:epc:id:sgln:0037000.00729.8202",
+							"attributes": [
+								{ "id": "cbvmda:sst", "attribute": "202" }
+							],
+							"children": [
+								"urn:epc:id:sgln:0037000.00729.8203"
+							]
+						},
+						{
+							"isA": "VocabularyElement",
+							"id": "urn:epc:id:sgln:0037000.00729.8203",
+							"attributes": [
+								{ "id": "cbvmda:sst", "attribute": "202" },
+								{ "id": "cbvmda:ssa", "attribute": "402" }
+							]
+						}
+					]
+				},
+				{
+					"type": "urn:epcglobal:epcis:vtype:ReadPoint",
+					"vocabularyElementList": [
+						{
+							"isA": "VocabularyElement",
+							"id": "urn:epc:id:sgln:0037000.00729.8201",
+							"attributes": [
+								{ "id": "cbvmda:site", "attribute": "0037000007296" },
+								{ "id": "cbvmda:sst", "attribute": 201 }
+							]
+						},
+						{
+							"isA": "VocabularyElement",
+							"id": "urn:epc:id:sgln:0037000.00729.8202",
+							"attributes": [
+								{ "id": "cbvmda:site", "attribute": "0037000007296" },
+								{ "id": "cbvmda:sst", "attribute": "202" }
+							]
+						},
+						{
+							"isA": "VocabularyElement",
+							"id": "urn:epc:id:sgln:0037000.00729.8203",
+							"attributes": [
+								{ "id": "cbvmda:sst", "attribute": 204 }
+							]
+						}
+					]
+				}
+			]
+		}
+	},
+	"epcisBody": {
+		"eventList": []
+	},
+	"@context": [
+		{
+			"isA": "@type",
+			"creationDate": {
+				"@id": "dcterms:created",
+				"@type": "xsd:dateTime"
+			},
+			"format": {
+				"@id": "dcterms:format",
+				"@type": "xsd:string"
+			},
+			"schemaVersion": {
+				"@id": "owl:versionInfo",
+				"@type": "xsd:string"
+			},
+			"type": {
+				"@type": "@id"
+			},
+			"id": {
+				"@type": "@id"
+			},
+			"children": {
+				"@type": "@id"
+			},
+			"@vocab": "https://ns.gs1.org/epcis-masterdata/",
+			"rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+			"rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+			"xsd": "http://www.w3.org/2001/XMLSchema#",
+			"dcterms": "http://purl.org/dc/terms/",
+			"epcis": "https://ns.gs1.org/epcis/",
+			"vtype": "urn:epcglobal:epcis:vtype",
+			"cbvmda": "urn:epcglobal:cbv:mda"
+		},
+		{
+			"xmda": "http://epcis.example.com/mda"
+		},
+		{
+			"example": "http://ns.example.com/epcis"
+		}
+	]
+}

--- a/JSON/WithDigitalLinkID/Example_9.6.1-ObjectEventWithDigitalLink.json
+++ b/JSON/WithDigitalLinkID/Example_9.6.1-ObjectEventWithDigitalLink.json
@@ -1,0 +1,128 @@
+{
+  "id": "_:document1",
+  "isA": "EPCISDocument",
+  "schemaVersion": 2.0,
+  "creationDate": "2005-07-11T11:30:47.0Z",
+  "format": "application/ld+json",
+  "epcisBody": {
+    "eventList": [
+      {
+        "id": "_:event_example_9_6_1_1",
+        "isA": "ObjectEvent",
+        "action": "OBSERVE",
+        "bizStep": "urn:epcglobal:cbv:bizstep:shipping",
+        "disposition": "urn:epcglobal:cbv:disp:in_transit",
+        "epcList": [ "https://id.gs1.org/01/70614141123451/21/2017", "https://id.gs1.org/21/2018/01/70614141123451" ],
+        "eventTime": "2005-04-03T20:33:31.116000-06:00",
+        "eventTimeZoneOffset": "-06:00",
+        "readPoint": "urn:epc:id:sgln:0614141.07346.1234",
+        "bizTransactionList": [
+          { "type": "urn:epcglobal:cbv:btt:po", "bizTransaction": "http://transaction.acme.com/po/12345678" }
+        ]
+      },
+      {
+        "id": "_:event_example_9_6_1_2",
+        "isA": "ObjectEvent",
+        "action": "OBSERVE",
+        "bizStep": "urn:epcglobal:cbv:bizstep:receiving",
+        "disposition": "urn:epcglobal:cbv:disp:in_progress",
+        "epcList": [ "https://id.gs1.org/01/70614141123451/21/2018" ],
+        "eventTime": "2005-04-04T20:33:31.116-06:00",
+        "eventTimeZoneOffset": "-06:00",
+        "readPoint": "urn:epc:id:sgln:0012345.11111.400",
+        "bizLocation": "urn:epc:id:sgln:0012345.11111.0",
+        "bizTransactionList": [
+          { "type": "urn:epcglobal:cbv:btt:po", "bizTransaction": "http://transaction.acme.com/po/12345678" },
+          { "type": "urn:epcglobal:cbv:btt:desadv", "bizTransaction": "urn:epcglobal:cbv:bt:0614141073467:1152" }
+        ],
+        "example:myField": "Example of a vendor/user extension"
+      }
+    ]
+  },
+  "@context": {
+    "@vocab": "https://ns.gs1.org/epcis/",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "dcterms": "http://purl.org/dc/terms/",
+    "epcis": "https://ns.gs1.org/epcis/",
+    "example": "http://ns.example.com/epcis/",
+    "eventTime": {
+      "@type": "xsd:dateTime"
+    },
+    "recordTime": {
+      "@type": "xsd:dateTime"
+    },
+    "declarationTime": {
+      "@type": "xsd:dateTime"
+    },
+    "eventTimeZoneOffset": {
+      "@type": "xsd:string"
+    },
+    "action": {
+      "@type": "xsd:string"
+    },
+    "quantity": {
+      "@type": "xsd:decimal"
+    },
+    "uom": {
+      "@type": "xsd:string"
+    },
+    "epcList": {
+      "@type": "@id"
+    },
+    "epcClass": {
+      "@type": "@id"
+    },
+    "parentID": {
+      "@type": "@id"
+    },
+    "childEPCs": {
+      "@type": "@id"
+    },
+    "inputEPCList": {
+      "@type": "@id"
+    },
+    "outputEPCList": {
+      "@type": "@id"
+    },
+    "bizStep": {
+      "@type": "@id"
+    },
+    "disposition": {
+      "@type": "@id"
+    },
+    "readPoint": {
+      "@type": "@id"
+    },
+    "bizLocation": {
+      "@type": "@id"
+    },
+    "bizTransaction": {
+      "@type": "@id"
+    },
+    "source": {
+      "@type": "@id"
+    },
+    "destination": {
+      "@type": "@id"
+    },
+    "type": {
+      "@type": "@id"
+    },
+    "isA": "@type",
+    "id": "@id",
+    "creationDate": {
+      "@id": "dcterms:created",
+      "@type": "xsd:dateTime"
+    },
+    "format": {
+      "@id": "dcterms:format",
+      "@type": "xsd:string"
+    },
+    "schemaVersion": {
+      "@id": "owl:versionInfo",
+      "@type": "xsd:string"
+    }
+  }
+}

--- a/JSON/WithDigitalLinkID/Example_9.6.2-ObjectEventWithDigitalLink.json
+++ b/JSON/WithDigitalLinkID/Example_9.6.2-ObjectEventWithDigitalLink.json
@@ -1,0 +1,121 @@
+{
+  "id": "_:document1",
+  "isA": "EPCISDocument",
+  "schemaVersion": 2.0,
+  "creationDate": "2005-07-11T11:30:47.0Z",
+  "format": "application/ld+json",
+  "epcisBody": {
+    "eventList": [
+      {
+        "id": "_:event_example_9_6_2_1",
+        "isA": "ObjectEvent",
+        "eventTime": "2013-06-08T14:58:56.591Z",
+        "eventTimeZoneOffset": "+02:00",
+        "action": "OBSERVE",
+        "bizStep": "urn:epcglobal:cbv:bizstep:receiving",
+        "disposition": "urn:epcglobal:cbv:disp:in_progress",
+        "readPoint": "urn:epc:id:sgln:0614141.00777.0",
+        "bizLocation": "urn:epc:id:sgln:0614141.00888.0",
+        "quantityList": [
+          { "epcClass": "https://id.gs1.org/01/70614141123451/10/998877", "quantity": 200, "uom": "KGM" }
+        ],
+        "sourceList": [
+          { "type": "urn:epcglobal:cbv:sdt:possessing_party", "source": "urn:epc:id:sgln:4012345.00001.0" },
+          { "type": "urn:epcglobal:cbv:sdt:location", "source": "urn:epc:id:sgln:4012345.00225.0" }
+        ],
+        "destinationList": [
+          { "type": "urn:epcglobal:cbv:sdt:owning_party", "destination": "urn:epc:id:sgln:0614141.00001.0" },
+          { "type": "urn:epcglobal:cbv:sdt:location", "destination": "urn:epc:id:sgln:0614141.00777.0" }
+        ],
+        "example:myField": "Example of a vendor/user extension"
+      }
+    ]
+  },
+  "@context": {
+    "@vocab": "https://ns.gs1.org/epcis/",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "dcterms": "http://purl.org/dc/terms/",
+    "epcis": "https://ns.gs1.org/epcis/",
+    "example": "http://ns.example.com/epcis/",
+    "eventTime": {
+      "@type": "xsd:dateTime"
+    },
+    "recordTime": {
+      "@type": "xsd:dateTime"
+    },
+    "declarationTime": {
+      "@type": "xsd:dateTime"
+    },
+    "eventTimeZoneOffset": {
+      "@type": "xsd:string"
+    },
+    "action": {
+      "@type": "xsd:string"
+    },
+    "quantity": {
+      "@type": "xsd:decimal"
+    },
+    "uom": {
+      "@type": "xsd:string"
+    },
+    "epcList": {
+      "@type": "@id"
+    },
+    "epcClass": {
+      "@type": "@id"
+    },
+    "parentID": {
+      "@type": "@id"
+    },
+    "childEPCs": {
+      "@type": "@id"
+    },
+    "inputEPCList": {
+      "@type": "@id"
+    },
+    "outputEPCList": {
+      "@type": "@id"
+    },
+    "bizStep": {
+      "@type": "@id"
+    },
+    "disposition": {
+      "@type": "@id"
+    },
+    "readPoint": {
+      "@type": "@id"
+    },
+    "bizLocation": {
+      "@type": "@id"
+    },
+    "bizTransaction": {
+      "@type": "@id"
+    },
+    "source": {
+      "@type": "@id"
+    },
+    "destination": {
+      "@type": "@id"
+    },
+    "type": {
+      "@type": "@id"
+    },
+    "isA": "@type",
+    "id": "@id",
+    "creationDate": {
+      "@id": "dcterms:created",
+      "@type": "xsd:dateTime"
+    },
+    "format": {
+      "@id": "dcterms:format",
+      "@type": "xsd:string"
+    },
+    "schemaVersion": {
+      "@id": "owl:versionInfo",
+      "@type": "xsd:string"
+    }
+  }
+}
+

--- a/JSON/WithDigitalLinkID/Example_9.6.3-AggregationEventWithDigitalLink.json
+++ b/JSON/WithDigitalLinkID/Example_9.6.3-AggregationEventWithDigitalLink.json
@@ -1,0 +1,116 @@
+{
+  "id": "_:document1",
+  "isA": "EPCISDocument",
+  "schemaVersion": 2.0,
+  "creationDate": "2005-07-11T11:30:47.0Z",
+  "format": "application/ld+json",
+  "epcisBody": {
+    "eventList": [
+      {
+        "id": "_:event_example_9_6_3_1",
+        "isA": "AggregationEvent",
+        "eventTime": "2013-06-08T14:58:56.591Z",
+        "eventTimeZoneOffset": "+02:00",
+        "parentID": "urn:epc:id:sscc:0614141.1234567890",
+        "childEPCs": [ "https://id.gs1.org/01/70614141123451/21/2017", "https://id.gs1.org/21/2018/01/70614141123451" ],
+        "action": "OBSERVE",
+        "bizStep": "urn:epcglobal:cbv:bizstep:receiving",
+        "disposition": "urn:epcglobal:cbv:disp:in_progress",
+        "readPoint": "urn:epc:id:sgln:0614141.00777.0",
+        "bizLocation": "urn:epc:id:sgln:0614141.00888.0",
+        "childQuantityList": [
+          { "epcClass": "https://id.gs1.org/01/04012345987652", "quantity": 10 },
+          { "epcClass": "https://id.gs1.org/01/04012345123456/10/998877", "quantity": 200.5, "uom": "KGM" }
+        ],
+        "example:myField": "Example of a vendor/user extension"
+      }
+    ]
+  },
+  "@context": {
+    "@vocab": "https://ns.gs1.org/epcis/",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "dcterms": "http://purl.org/dc/terms/",
+    "epcis": "https://ns.gs1.org/epcis/",
+    "example": "http://ns.example.com/epcis/",
+    "eventTime": {
+      "@type": "xsd:dateTime"
+    },
+    "recordTime": {
+      "@type": "xsd:dateTime"
+    },
+    "declarationTime": {
+      "@type": "xsd:dateTime"
+    },
+    "eventTimeZoneOffset": {
+      "@type": "xsd:string"
+    },
+    "action": {
+      "@type": "xsd:string"
+    },
+    "quantity": {
+      "@type": "xsd:decimal"
+    },
+    "uom": {
+      "@type": "xsd:string"
+    },
+    "epcList": {
+      "@type": "@id"
+    },
+    "epcClass": {
+      "@type": "@id"
+    },
+    "parentID": {
+      "@type": "@id"
+    },
+    "childEPCs": {
+      "@type": "@id"
+    },
+    "inputEPCList": {
+      "@type": "@id"
+    },
+    "outputEPCList": {
+      "@type": "@id"
+    },
+    "bizStep": {
+      "@type": "@id"
+    },
+    "disposition": {
+      "@type": "@id"
+    },
+    "readPoint": {
+      "@type": "@id"
+    },
+    "bizLocation": {
+      "@type": "@id"
+    },
+    "bizTransaction": {
+      "@type": "@id"
+    },
+    "source": {
+      "@type": "@id"
+    },
+    "destination": {
+      "@type": "@id"
+    },
+    "type": {
+      "@type": "@id"
+    },
+    "isA": "@type",
+    "id": "@id",
+    "creationDate": {
+      "@id": "dcterms:created",
+      "@type": "xsd:dateTime"
+    },
+    "format": {
+      "@id": "dcterms:format",
+      "@type": "xsd:string"
+    },
+    "schemaVersion": {
+      "@id": "owl:versionInfo",
+      "@type": "xsd:string"
+    }
+  }
+}
+

--- a/JSON/WithDigitalLinkID/Example_9.6.4-TransformationEventWithDigitalLink.json
+++ b/JSON/WithDigitalLinkID/Example_9.6.4-TransformationEventWithDigitalLink.json
@@ -1,0 +1,124 @@
+{
+  "id": "_:document1",
+  "isA": "EPCISDocument",
+  "schemaVersion": 2.0,
+  "creationDate": "2013-06-04T14:59:02.099+02:00",
+  "format": "application/ld+json",
+  "epcisBody": {
+    "eventList": [
+      {
+        "id": "_:event_example_9_6_4_1",
+        "isA": "TransformationEvent",
+        "eventTime": "2013-10-31T14:58:56.591Z",
+        "eventTimeZoneOffset": "+02:00",
+        "inputEPCList": [ "urn:epc:id:sgtin:4012345.011122.25", "urn:epc:id:sgtin:4000001.065432.99886655" ],
+        "inputQuantityList": [
+          { "epcClass": "urn:epc:class:lgtin:4012345.011111.4444", "quantity": 10, "uom": "KGM" },
+          { "epcClass": "https://id.gs1.org/01/00614141777778/10/987", "quantity": 30 },
+          { "epcClass": "https://id.gs1.org/01/04012345666663", "quantity": 220 }
+        ],
+        "outputEPCList": [
+          "urn:epc:id:sgtin:4012345.077889.25",
+          "urn:epc:id:sgtin:4012345.077889.26",
+          "urn:epc:id:sgtin:4012345.077889.27",
+          "urn:epc:id:sgtin:4012345.077889.28"
+        ],
+        "bizStep": "urn:epcglobal:cbv:bizstep:commissioning",
+        "disposition": "urn:epcglobal:cbv:disp:in_progress",
+        "readPoint": "urn:epc:id:sgln:4012345.00001.0",
+        "ilmd": {
+          "example:bestBeforeDate": "2014-12-10",
+          "example:batch": "XYZ"
+        },
+        "example:myField": "Example of a vendor/user extension"
+      }
+    ]
+  },
+  "@context": {
+    "@vocab": "https://ns.gs1.org/epcis/",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "dcterms": "http://purl.org/dc/terms/",
+    "epcis": "https://ns.gs1.org/epcis/",
+    "example": "http://ns.example.com/epcis/",
+    "eventTime": {
+      "@type": "xsd:dateTime"
+    },
+    "recordTime": {
+      "@type": "xsd:dateTime"
+    },
+    "declarationTime": {
+      "@type": "xsd:dateTime"
+    },
+    "eventTimeZoneOffset": {
+      "@type": "xsd:string"
+    },
+    "action": {
+      "@type": "xsd:string"
+    },
+    "quantity": {
+      "@type": "xsd:decimal"
+    },
+    "uom": {
+      "@type": "xsd:string"
+    },
+    "epcList": {
+      "@type": "@id"
+    },
+    "epcClass": {
+      "@type": "@id"
+    },
+    "parentID": {
+      "@type": "@id"
+    },
+    "childEPCs": {
+      "@type": "@id"
+    },
+    "inputEPCList": {
+      "@type": "@id"
+    },
+    "outputEPCList": {
+      "@type": "@id"
+    },
+    "bizStep": {
+      "@type": "@id"
+    },
+    "disposition": {
+      "@type": "@id"
+    },
+    "readPoint": {
+      "@type": "@id"
+    },
+    "bizLocation": {
+      "@type": "@id"
+    },
+    "bizTransaction": {
+      "@type": "@id"
+    },
+    "source": {
+      "@type": "@id"
+    },
+    "destination": {
+      "@type": "@id"
+    },
+    "type": {
+      "@type": "@id"
+    },
+    "isA": "@type",
+    "id": "@id",
+    "creationDate": {
+      "@id": "dcterms:created",
+      "@type": "xsd:dateTime"
+    },
+    "format": {
+      "@id": "dcterms:format",
+      "@type": "xsd:string"
+    },
+    "schemaVersion": {
+      "@id": "owl:versionInfo",
+      "@type": "xsd:string"
+    }
+  }
+}
+


### PR DESCRIPTION
[First push request]
In implementing capture interface for json-formatted documents, 
it is founded that some minor syntax error on AssociationEvent-g.jsonld and AssociationEvent-h.jsonld, thus fixed and reported.

Also, in implementing digital link ID support for some appropriate fields (e.g., epcList),
I am sharing some documents where each of them is a modified version of Example 9.6.* and has been tested.
I hope they are helpful.

[Second push request]
Second push request is for JSON/Example_9.8.1-MasterData.json.
It seems like the document cannot pass the validation for the json schema. 
I share the modified version with my best guess. 