### PR TITLE
singular form for eventType enum for sake of consistency

### DIFF
--- a/REST Bindings/query-schema.json
+++ b/REST Bindings/query-schema.json
@@ -7,11 +7,11 @@
       "items": {
         "type": "string",
         "enum": [
-          "ObjectEvents",
-          "AggregationEvents",
-          "AssociationEvents",
-          "TransformationEvents",
-          "TransactionEvents",
+          "ObjectEvent",
+          "AggregationEvent",
+          "AssociationEvent",
+          "TransformationEvent",
+          "TransactionEvent",
           "all"
         ]
       }


### PR DESCRIPTION
Hi @joelvogt, @mgh128,

A minor change in query schema to have eventType enum values as singular.