### PR TITLE
Keeping JSON Capture Schema in sync with SHACL capture validation Schema

### DIFF
--- a/JSON/EPCIS-JSON-Schema.json
+++ b/JSON/EPCIS-JSON-Schema.json
@@ -67,7 +67,7 @@
 		"errorDeclaration": {
 			"type": "object",
 			"properties": {
-				"declarationtime": {
+				"declarationTime": {
 					"$ref": "#/definitions/time"
 				},
 				"reason": {
@@ -79,7 +79,8 @@
 						"$ref": "#/definitions/eventID"
 					}
 				}
-			}
+			},
+			"required": ["declarationTime", "reason", "correctiveEventIDs"]
 		},
 		"quantityElement": {
 			"type": "object",
@@ -94,7 +95,7 @@
 					"$ref": "#/definitions/uom"
 				}
 			},
-			"required": ["epcClass"]
+			"required": ["epcClass", "quantity"]
 		},
 		"bizTransaction": {
 			"type": "object",
@@ -118,7 +119,7 @@
 					"$ref": "#/definitions/uri"
 				}
 			},
-			"required": ["type"]
+			"required": ["type", "source"]
 		},
 		"destination": {
 			"type": "object",
@@ -130,7 +131,7 @@
 					"$ref": "#/definitions/uri"
 				}
 			},
-			"required": ["type"]
+			"required": ["type", "destination"]
 		},
 		"sensorElement": {
 			"type": "object",

--- a/JSON/EPCIS-JSON-Schema.json
+++ b/JSON/EPCIS-JSON-Schema.json
@@ -925,7 +925,19 @@
 						"$ref": "#/definitions/associationEvent"
 					}
 				}
-			]
+			],
+			"properties": {
+				"isA": {
+					"type": "string",
+					"enum": [
+						"AssociationEvent",
+						"ObjectEvent",
+						"AggregationEvent",
+						"TransactionEvent",
+						"TransformationEvent"
+					]
+				}
+			}
 		},
 		"vocabulary": {
 			"type": "object",


### PR DESCRIPTION
Changes made in JSON Query Schema file:

1) In errorDeclaration definition, declarationTime was not properly indented. 

2) In errorDeclaration definition, mandatory field constraint were missing for fields "declarationTime", "reason" and "correctiveEventIDs.

3) In quantityElement definition, mandatory field constraint was missing for field "quantity".

4) In source definition, mandatory field constraint was missing for field "source".

5) In destination definition, mandatory field constraint was missing for field "destination".

6) In onlyValidEvent definition, isA field validation was missing to have the only valid event types. 