### PR TITLE
allow master data attributes of type string, number or object

### DIFF
--- a/JSON/EPCIS-JSON-Schema.json
+++ b/JSON/EPCIS-JSON-Schema.json
@@ -1000,7 +1000,16 @@
 					"$ref": "#/definitions/uri"
 				},
 				"attribute": {
-					"type": "object"
+					"anyOf": [{
+							"type": "number"
+						},
+						{
+							"type": "string"
+						},
+						{
+							"type": "object"
+						}
+                    ]
 				}
 			},
 			"required": ["id"]


### PR DESCRIPTION
Hi @mgh128, @joelvogt,

It is observed in Example_9.8.1-MasterData-complying-with-schema.json that attribute value can be of simple value or complex object for master data

For example,

`"attribute": "+18.0000" // simple value`

or

```
{
  "attribute": {
    "@context": {
      "@vocab": "http://epcis.example.com/ns/"
    },
    "isA": "Address",
    "street": "100 Nowhere Street",
    "city": "Fancy",
    "state": "DC",
    "zip": "99999"
  }
}
```

Current schema won't allow "attribute": "+18.0000".  Therefore, updating schema to allow string, number & complex object as well.

See if it makes sense.