### PR TITLE
better to separate properties and patternProperties

### DIFF
--- a/REST Bindings/query-schema.json
+++ b/REST Bindings/query-schema.json
@@ -1,7 +1,7 @@
 {
   "title": "EPCIS Query parameters",
   "type": "object",
-  "patternProperties": {
+  "properties": {
     "eventType": {
       "type": "array",
       "items": {
@@ -162,6 +162,34 @@
         "format": "uri"
       }
     },
+    "EQ_eventID": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "GE_errorDeclaration_Time": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "LT_errorDeclaration_Time": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "EQ_errorReason": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "EQ_correctiveEventID": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "patternProperties": {
     "^EQ_[a-z]\\w+$": {
       "oneOf": [
         {
@@ -505,32 +533,6 @@
       }
     },
     "^EQ_ATTR_\\w+_attrname$": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "EQ_eventID": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "GE_errorDeclaration_Time": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "LT_errorDeclaration_Time": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "EQ_errorReason": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "EQ_correctiveEventID": {
       "type": "array",
       "items": {
         "type": "string"


### PR DESCRIPTION
Hi @mgh128,

This PR is about making query-schema properties more organised.

The parameters that does not have regex can be placed under "properties" tag and parameters with regex can be placed under "patternProperties" tag. This can make the schema more organised by placing the parameters under rightly deserving tags.

Let us know what do you think?