### PR TITLE
update jsonld context schema to allow it in array structure

### DIFF
--- a/JSON/EPCIS-JSON-Schema.json
+++ b/JSON/EPCIS-JSON-Schema.json
@@ -1083,16 +1083,30 @@
 					"const": "EPCISDocument"
 				},
 				"@context": {
-					"anyOf": [{
+					"anyOf": [
+						{
 							"type": "string",
 							"format": "uri"
 						},
 						{
 							"type": "object"
+						},
+						{
+							"type": "array",
+							"uniqueItems": true,
+							"items": {
+								"anyOf": [{
+										"type": "string",
+										"format": "uri"
+									},
+									{
+										"type": "object"
+									}
+								]
+							}
 						}
 					]
 				},
-
 				"schemaVersion": {
 					"type": "number"
 				},
@@ -1125,12 +1139,27 @@
 					"const": "EPCISQueryDocument"
 				},
 				"@context": {
-					"anyOf": [{
+					"anyOf": [
+						{
 							"type": "string",
 							"format": "uri"
 						},
 						{
-							"type": "object"
+							"format": "object"
+						},
+						{
+							"type": "array",
+							"uniqueItems": true,
+							"items": {
+								"anyOf": [{
+										"type": "string",
+										"format": "uri"
+									},
+									{
+										"type": "object"
+									}
+								]
+							}
 						}
 					]
 				},


### PR DESCRIPTION
Hi @mgh128, Updated schema as json-ld context would be always be in array structure. Without this change schema validation was failing for example events present in repo.