### PR TITLE
fixed typo in description of GET queries/{queryName}

### DIFF
--- a/REST Bindings/openapi.yaml
+++ b/REST Bindings/openapi.yaml
@@ -1440,7 +1440,7 @@ paths:
           description: >
             The EPCIS query body, either for EPCIS events or master data resources. A GET on a named query
             will not return results. To retrieve EPCIS events or master data, use the `/queries/{queryName}/events`
-            or `/queries/{namedQuery}/masterdata` respectively.
+            or `/queries/{queryName}/masterdata` respectively.
           content:
             application/json:
               schema:


### PR DESCRIPTION
Hi @joelvogt , fixed minor typo which you can quickly review and merge.