### PR TITLE
removed string and array type defintion for JSON-LD context from query schema

### DIFF
--- a/REST Bindings/query-schema.json
+++ b/REST Bindings/query-schema.json
@@ -3,30 +3,19 @@
   "type": "object",
   "properties": {
     "@context": {
-      "anyOf": [
-        {
-          "type": "string",
-          "format": "uri"
-        },
-        {
-          "type": "object"
-        },
-        {
-          "type": "array",
-          "uniqueItems": true,
-          "items": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "uri"
-              },
-              {
-                "type": "object"
-              }
-            ]
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "anyOf": [
+          {
+            "type": "string",
+            "format": "uri"
+          },
+          {
+            "type": "object"
           }
-        }
-      ]
+        ]
+      }
     },
     "eventType": {
       "type": "array",


### PR DESCRIPTION
Hi @mgh128, @joelvogt,

For query schema, it is sufficient to have object type for JSON-LD context. Default schema and array in queries are not relevant hence removed.