### PR TITLE
fixed typo in description of GET /queries/{queryName}/events endpoint

### DIFF
--- a/REST Bindings/openapi.yaml
+++ b/REST Bindings/openapi.yaml
@@ -1603,7 +1603,7 @@ paths:
         - $ref: '#/components/parameters/ReportIfEmpty'
       description: >
         The `GET` endpoint is to retrieve large results that don't fit into the response of `POST` request.
-        It can also be used to subscribe to anonymous queries.
+        It can also be used to subscribe to named queries.
       responses:
         '101':
          $ref: '#/components/responses/101WebsocketCreated'


### PR DESCRIPTION
Hi @joelvogt ,

Have fixed a minor typo in description of GET method in /queries/{queryName}/events endpoint.