### PR TITLE
changed eventID value to hash URI

### DIFF
--- a/JSON/AssociationEvent/AssociationEvent-a.jsonld
+++ b/JSON/AssociationEvent/AssociationEvent-a.jsonld
@@ -9,7 +9,7 @@
   "epcisBody": {
    "eventList": [
      {
-		  "eventID": "_:event_a",
+		  "eventID": "ni:///sha-256;025ac144187a8c5e14caf4d1cfa69250a33dc59a5bc42a68d31b1b5e55a3f15a?ver=CBV2.0",
 		  "isA": "AssociationEvent",
 		  "eventTime": "2019-11-01T14:00:00.000+01:00",
 		  "eventTimeZoneOffset": "+01:00",

--- a/JSON/AssociationEvent/AssociationEvent-b.jsonld
+++ b/JSON/AssociationEvent/AssociationEvent-b.jsonld
@@ -9,7 +9,7 @@
   "epcisBody": {
    "eventList": [
      {
-		  "eventID": "_:event_b",
+		  "eventID": "ni:///sha-256;a15e0b457cfc95305b6d530978c4cd7965bb29c0b8c312310fc7210c9ef123d9?ver=CBV2.0",
 		  "isA": "AssociationEvent",
 		  "eventTime": "2019-11-02T14:00:00.000+01:00",
 		  "eventTimeZoneOffset": "+01:00",

--- a/JSON/AssociationEvent/AssociationEvent-c.jsonld
+++ b/JSON/AssociationEvent/AssociationEvent-c.jsonld
@@ -9,7 +9,7 @@
   "epcisBody": {
    "eventList": [
      {
-		  "eventID": "_:event_c",
+		  "eventID": "ni:///sha-256;371c8eb1834fe5bca8722458310287d40d046c5bf032a484a8274299f7be2f59?ver=CBV2.0",
 		  "isA": "AssociationEvent",
 		  "eventTime": "2019-11-03T14:00:00.000+01:00",
 		  "eventTimeZoneOffset": "+01:00",

--- a/JSON/AssociationEvent/AssociationEvent-d.jsonld
+++ b/JSON/AssociationEvent/AssociationEvent-d.jsonld
@@ -9,7 +9,7 @@
   "epcisBody": {
    "eventList": [
      {
-		  "eventID": "_:event_d",
+		  "eventID": "ni:///sha-256;8a2d6f46deae4e62f517b2d2f84d2251b0c2db43b791663575e9ff358560fd85?ver=CBV2.0",
 		  "isA": "AssociationEvent",
 		  "eventTime": "2019-11-04T14:00:00.000+01:00",
 		  "eventTimeZoneOffset": "+01:00",

--- a/JSON/AssociationEvent/AssociationEvent-e.jsonld
+++ b/JSON/AssociationEvent/AssociationEvent-e.jsonld
@@ -9,7 +9,7 @@
   "epcisBody": {
    "eventList": [
      {
-		  "eventID": "_:event_e",
+		  "eventID": "ni:///sha-256;8bbf932aa86072c4e5e6e58666b9344447c3811e07823677c336a00d7db67e5a?ver=CBV2.0",
 		  "isA": "AssociationEvent",
 		  "eventTime": "2019-11-05T14:00:00.000+01:00",
 		  "eventTimeZoneOffset": "+01:00",

--- a/JSON/AssociationEvent/AssociationEvent-f.jsonld
+++ b/JSON/AssociationEvent/AssociationEvent-f.jsonld
@@ -9,7 +9,7 @@
   "epcisBody": {
    "eventList": [
      {
-		  "eventID": "_:event_f",
+		  "eventID": "ni:///sha-256;5f7c472bc4905de27a19b2efc8e4a9c6dc195139669b80b515f12218ff07cf65?ver=CBV2.0",
 		  "isA": "AssociationEvent",
 		  "eventTime": "2019-11-06T14:00:00.000+01:00",
 		  "recordTime": "2019-11-06T14:05:00.000+01:00",

--- a/JSON/AssociationEvent/AssociationEvent-g.jsonld
+++ b/JSON/AssociationEvent/AssociationEvent-g.jsonld
@@ -9,7 +9,7 @@
   "epcisBody": {
    "eventList": [
      {
-		  "eventID": "_:event_g",
+		  "eventID": "ni:///sha-256;3acf0f5d06f13134ea8899b9a711eb4d4039dfefd73f2093136729296d904d9a?ver=CBV2.0",
 		  "isA": "AssociationEvent",
 		  "eventTime": "2019-11-04T14:00:00.000+01:00",
 		  "eventTimeZoneOffset": "+01:00",

--- a/JSON/AssociationEvent/AssociationEvent-h.jsonld
+++ b/JSON/AssociationEvent/AssociationEvent-h.jsonld
@@ -9,7 +9,7 @@
   "epcisBody": {
    "eventList": [
      {
-		  "eventID": "_:event_h",
+		  "eventID": "ni:///sha-256;fec9667280c4710a3fa9558b7bc8ddc2ced0dc442d87f82becae24bb6ca6a46f?ver=CBV2.0",
 		  "isA": "AssociationEvent",
 		  "eventTime": "2019-11-04T14:00:00.000+01:00",
 		  "eventTimeZoneOffset": "+01:00",

--- a/JSON/Example_9.6.1-ObjectEvent-with-error-declaration.json
+++ b/JSON/Example_9.6.1-ObjectEvent-with-error-declaration.json
@@ -9,7 +9,7 @@
   "epcisBody": {
    "eventList": [
      {
-		  "eventID": "_:event1",
+		  "eventID": "ni:///sha-256;aa49daa1fe0b773e0437e546078dc87de9c864d5b9babe84488f31478887fdf3?ver=CBV2.0",
 		  "isA": "ObjectEvent",
 		  "action": "OBSERVE",
 		  "bizStep": "urn:epcglobal:cbv:bizstep:shipping",
@@ -30,7 +30,7 @@
      },
 
      {
-		  "eventID": "_:event2",
+		  "eventID": "ni:///sha-256;00e1e6eba3a7cc6125be4793a631f0af50f8322e0ab5f2c0bab994a11cec1d79?ver=CBV2.0",
 		  "isA": "ObjectEvent",
 		  "action": "OBSERVE",
 		  "bizStep": "urn:epcglobal:cbv:bizstep:receiving",

--- a/JSON/Example_9.6.1-ObjectEvent.jsonld
+++ b/JSON/Example_9.6.1-ObjectEvent.jsonld
@@ -9,7 +9,7 @@
   "epcisBody": {
    "eventList": [
      {
-		  "eventID": "_:event1",
+		  "eventID": "ni:///sha-256;df7bb3c352fef055578554f09f5e2aa41782150ced7bd0b8af24dd3ccb30ba69?ver=CBV2.0",
 		  "isA": "ObjectEvent",
 		  "action": "OBSERVE",
 		  "bizStep": "urn:epcglobal:cbv:bizstep:shipping",
@@ -22,7 +22,7 @@
      },
 
      {
-		  "eventID": "_:event2",
+		  "eventID": "ni:///sha-256;00e1e6eba3a7cc6125be4793a631f0af50f8322e0ab5f2c0bab994a11cec1d79?ver=CBV2.0",
 		  "isA": "ObjectEvent",
 		  "action": "OBSERVE",
 		  "bizStep": "urn:epcglobal:cbv:bizstep:receiving",

--- a/JSON/Example_9.6.2-ObjectEvent.jsonld
+++ b/JSON/Example_9.6.2-ObjectEvent.jsonld
@@ -9,7 +9,7 @@
   "epcisBody": {
    "eventList": [
      {
-		  "eventID": "_:event1",
+		  "eventID": "ni:///sha-256;a98f08ae6ac4de3482054314d637c07010b448d3802dccb028a06aafcc6a4b10?ver=CBV2.0",
 		  "isA": "ObjectEvent",
 		  "eventTime": "2013-06-08T14:58:56.591Z",
 		  "eventTimeZoneOffset": "+02:00",

--- a/JSON/Example_9.6.3-AggregationEvent.jsonld
+++ b/JSON/Example_9.6.3-AggregationEvent.jsonld
@@ -9,7 +9,7 @@
   "epcisBody": {
    "eventList": [
      {
-		  "eventID": "_:event1",
+		  "eventID": "ni:///sha-256;87b5f18a69993f0052046d4687dfacdf48f7c988cfabda2819688c86b4066a49?ver=CBV2.0",
 		  "isA": "AggregationEvent",
 		  "eventTime": "2013-06-08T14:58:56.591Z",
 		  "eventTimeZoneOffset": "+02:00",

--- a/JSON/Example_9.6.4-TransformationEvent.jsonld
+++ b/JSON/Example_9.6.4-TransformationEvent.jsonld
@@ -9,7 +9,7 @@
   "epcisBody": {
    "eventList": [
      {
-		  "eventID": "_:event1",
+		  "eventID": "ni:///sha-256;e65c3a997e77f34b58306da7a82ab0fc91c7820013287700f0b50345e5795b97?ver=CBV2.0",
 		  "isA": "TransformationEvent",
 		  "eventTime": "2013-10-31T14:58:56.591Z",
 		  "eventTimeZoneOffset": "+02:00",

--- a/JSON/PersistentDisposition-example.jsonld
+++ b/JSON/PersistentDisposition-example.jsonld
@@ -9,7 +9,7 @@
   "epcisBody": {
    "eventList": [
      {
-		  "id": "_:event1",
+		  "id": "ni:///sha-256;56ba4f355c57456b41c3fb60b22d8342e759de503e3e618940ca3b6ad1bf9b00?ver=CBV2.0",
 		  "isA": "AggregationEvent",
 		  "eventTime": "2020-06-07T17:10:16Z",
 		  "eventTimeZoneOffset": "+02:00",
@@ -48,7 +48,7 @@
      },
      
      {
-		  "id": "_:event2",
+		  "id": "ni:///sha-256;dae7b481207bb87f1d981c5f169b8138368ae152a41b002eaf36eca1f67d56f5?ver=CBV2.0",
 		  "isA": "AggregationEvent",
 		  "eventTime": "2020-06-08T18:11:16Z",
 		  "eventTimeZoneOffset": "+02:00",

--- a/JSON/WithDigitalLinkID/Example_9.6.1-ObjectEventWithDigitalLink.jsonld
+++ b/JSON/WithDigitalLinkID/Example_9.6.1-ObjectEventWithDigitalLink.jsonld
@@ -8,7 +8,7 @@
   "epcisBody": {
     "eventList": [
       {
-        "eventID": "_:event_example_9_6_1_1",
+        "eventID": "ni:///sha-256;9fa42e8bf64e1cfe152d582a248646ce0ad2b0c6826c7e8ed95442a7a1545f33?ver=CBV2.0",
         "isA": "ObjectEvent",
         "action": "OBSERVE",
         "bizStep": "urn:epcglobal:cbv:bizstep:shipping",
@@ -22,7 +22,7 @@
         ]
       },
       {
-        "eventID": "_:event_example_9_6_1_2",
+        "eventID": "ni:///sha-256;4217c6a122625b7b9d8ae4f9b89890df35ffa0c501471a096cbfdeebd7207e45?ver=CBV2.0",
         "isA": "ObjectEvent",
         "action": "OBSERVE",
         "bizStep": "urn:epcglobal:cbv:bizstep:receiving",

--- a/JSON/WithDigitalLinkID/Example_9.6.2-ObjectEventWithDigitalLink.jsonld
+++ b/JSON/WithDigitalLinkID/Example_9.6.2-ObjectEventWithDigitalLink.jsonld
@@ -8,7 +8,7 @@
   "epcisBody": {
     "eventList": [
       {
-        "eventID": "_:event_example_9_6_2_1",
+        "eventID": "ni:///sha-256;115b14983df54a9bcc3dd6a00dc4ebcab000bd52fda0abdd8996907e01dccc23?ver=CBV2.0",
         "isA": "ObjectEvent",
         "eventTime": "2013-06-08T14:58:56.591Z",
         "eventTimeZoneOffset": "+02:00",

--- a/JSON/WithDigitalLinkID/Example_9.6.3-AggregationEventWithDigitalLink.jsonld
+++ b/JSON/WithDigitalLinkID/Example_9.6.3-AggregationEventWithDigitalLink.jsonld
@@ -8,7 +8,7 @@
   "epcisBody": {
     "eventList": [
       {
-        "eventID": "_:event_example_9_6_3_1",
+        "eventID": "ni:///sha-256;20a2b5b9681b7a70413c42bfe72db61386411252a803b6bc212f5f46f26649d7?ver=CBV2.0",
         "isA": "AggregationEvent",
         "eventTime": "2013-06-08T14:58:56.591Z",
         "eventTimeZoneOffset": "+02:00",

--- a/JSON/WithDigitalLinkID/Example_9.6.4-TransformationEventWithDigitalLink.jsonld
+++ b/JSON/WithDigitalLinkID/Example_9.6.4-TransformationEventWithDigitalLink.jsonld
@@ -8,7 +8,7 @@
   "epcisBody": {
     "eventList": [
       {
-        "eventID": "_:event_example_9_6_4_1",
+        "eventID": "ni:///sha-256;4f143d1adf7b2950a34f5e82a240ce5280530b06a9f3c2b9cfe49f5ca5001815?ver=CBV2.0",
         "isA": "TransformationEvent",
         "eventTime": "2013-10-31T14:58:56.591Z",
         "eventTimeZoneOffset": "+02:00",

--- a/JSON/WithSensorData/SensorDataExample1.jsonld
+++ b/JSON/WithSensorData/SensorDataExample1.jsonld
@@ -9,7 +9,7 @@
   "epcisBody": {
    "eventList": [
      {
-		  "eventID": "_:event1",
+		  "eventID": "ni:///sha-256;74f1dc48ee22289bc40ddd9f1d0ecae0dd09a2f4c3dfa66fdbca16cb2d8a4e77?ver=CBV2.0",
 		  "isA": "ObjectEvent",
 		  "action": "OBSERVE",
 		  "bizStep": "urn:epcglobal:cbv:bizstep:inspecting",

--- a/JSON/WithSensorData/SensorDataExample11.jsonld
+++ b/JSON/WithSensorData/SensorDataExample11.jsonld
@@ -8,7 +8,7 @@
   "epcisBody": {
     "eventList": [
       {
-		"eventID": "_:event11",
+		"eventID": "ni:///sha-256;8702ac80df8ac48d19cc0c8d19399249fc7037f8b752acb97baf7148960d2a17?ver=CBV2.0",
         "isA": "TransactionEvent",
         "eventTime": "2020-07-03T00:05:00-06:00",
         "eventTimeZoneOffset": "-06:00",

--- a/JSON/WithSensorData/SensorDataExample1b.jsonld
+++ b/JSON/WithSensorData/SensorDataExample1b.jsonld
@@ -9,7 +9,7 @@
   "epcisBody": {
    "eventList": [
      {
-		  "eventID": "_:event1",
+		  "eventID": "ni:///sha-256;e84840e98e15b9c86168ce85ca277af4241dddd3b658f9650a00096c2a09c2f3?ver=CBV2.0",
 		  "isA": "ObjectEvent",
 		  "action": "OBSERVE",
 		  "bizStep": "urn:epcglobal:cbv:bizstep:inspecting",

--- a/JSON/WithSensorData/SensorDataExample2.jsonld
+++ b/JSON/WithSensorData/SensorDataExample2.jsonld
@@ -9,7 +9,7 @@
   "epcisBody": {
    "eventList": [
      {
-		  "eventID": "_:event2",
+		  "eventID": "ni:///sha-256;0301ed4c40065cde36eb9cc80780312d903a031a91d105639df4e649a9d01200?ver=CBV2.0",
 		  "isA": "ObjectEvent",
 		  "action": "OBSERVE",
 		  "bizStep": "urn:epcglobal:cbv:bizstep:inspecting",

--- a/JSON/WithSensorData/SensorDataExample3.jsonld
+++ b/JSON/WithSensorData/SensorDataExample3.jsonld
@@ -9,7 +9,7 @@
   "epcisBody": {
    "eventList": [
      {
-		  "eventID": "_:event3",
+		  "eventID": "ni:///sha-256;b507b2720c96cd99855eabb101e8617d48622eff4ceaad0a416b3c10dfd316ee?ver=CBV2.0",
 		  "isA": "ObjectEvent",
 		  "action": "OBSERVE",
 		  "bizStep": "urn:epcglobal:cbv:bizstep:inspecting",

--- a/JSON/WithSensorData/SensorDataExample4.jsonld
+++ b/JSON/WithSensorData/SensorDataExample4.jsonld
@@ -9,7 +9,7 @@
   "epcisBody": {
   "eventList": [
      {
-		  "eventID": "_:event4",
+		  "eventID": "ni:///sha-256;7ff1501099b3f5890d310d703fb9f57e251bba0c57d3c049fab590b50323a8e7?ver=CBV2.0",
 		  "isA": "ObjectEvent",
 		  "action": "OBSERVE",
 		  "bizStep": "urn:epcglobal:cbv:bizstep:inspecting",

--- a/JSON/WithSensorData/SensorDataExample5.jsonld
+++ b/JSON/WithSensorData/SensorDataExample5.jsonld
@@ -9,7 +9,7 @@
   "epcisBody": {
   "eventList": [
      {
-		  "eventID": "_:event5",
+		  "eventID": "ni:///sha-256;e13ff14a9b4f3dd11bba60315ed9b849eb8ddf4c5b1a9aa794cd250256730834?ver=CBV2.0",
 		  "isA": "ObjectEvent",
 		  "action": "OBSERVE",
 		  "bizStep": "urn:epcglobal:cbv:bizstep:inspecting",

--- a/JSON/WithSensorData/SensorDataExample6.jsonld
+++ b/JSON/WithSensorData/SensorDataExample6.jsonld
@@ -9,7 +9,7 @@
   "epcisBody": {
   "eventList": [
      {
-		  "eventID": "_:event6",
+		  "eventID": "ni:///sha-256;6aca25c45463182fe3a1ebf60a6b81a165f061b58f4f3c202eb423234386b72e?ver=CBV2.0",
 		  "isA": "ObjectEvent",
 		  "action": "OBSERVE",
 		  "bizStep": "urn:epcglobal:cbv:bizstep:inspecting",

--- a/JSON/WithSensorData/SensorDataExample7.jsonld
+++ b/JSON/WithSensorData/SensorDataExample7.jsonld
@@ -9,7 +9,7 @@
   "epcisBody": {
   "eventList": [
      {
-		  "eventID": "_:event7",
+		  "eventID": "ni:///sha-256;db924230b77cc4d9a7cea4968fd302b06598a2b63e1b0ea011b31d1b5f45e6ac?ver=CBV2.0",
 		  "isA": "ObjectEvent",
 		  "action": "OBSERVE",
 		  "bizStep": "urn:epcglobal:cbv:bizstep:inspecting",

--- a/JSON/WithSensorData/SensorDataExample8.jsonld
+++ b/JSON/WithSensorData/SensorDataExample8.jsonld
@@ -9,7 +9,7 @@
   "epcisBody": {
   "eventList": [
      {
-		  "eventID": "_:event8",
+		  "eventID": "ni:///sha-256;18454584ed96fbb533e4a69b01eefd1bff3edd1e80ef8598957111f4477a0a64?ver=CBV2.0",
 		  "isA": "AggregationEvent",
 		  "action": "ADD",
 		  "bizStep": "urn:epcglobal:cbv:bizstep:packing",


### PR DESCRIPTION
Hi @mgh128 ,

As discussed in yesterday's call, We have changed the value of eventID to hash URI in each example under the JSON folder.

Note: We couldn't generate the hash for [Example_9.6.1-with-comment.jsonld](https://github.com/gs1/EPCIS/blob/master/JSON/Example_9.6.1-with-comment.jsonld) . Looks like the comment part is not yet supported in the event hash generator. We will troubleshoot the error at the event hash generator to see if it is quick to fix.

We will generate separate PR for Example_9.6.1-with-comment.jsonld](https://github.com/gs1/EPCIS/blob/master/JSON/Example_9.6.1-with-comment.jsonld) .