### PR TITLE
Turtle examples corresponding to all JSONLD examples

### DIFF
--- a/Turtle/AssociationEvent/AssociationEvent-a.ttl
+++ b/Turtle/AssociationEvent/AssociationEvent-a.ttl
@@ -1,0 +1,27 @@
+@prefix epcis: <https://ns.gs1.org/epcis/> .
+@prefix gs1:   <https://gs1.org/voc/> .
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix vtype: <urn:epcglobal:epcis:vtype:> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix example: <http://ns.example.com/epcis/> .
+@prefix cbvmda: <urn:epcglobal:cbv:mda:> .
+
+<ni:///sha-256;025ac144187a8c5e14caf4d1cfa69250a33dc59a5bc42a68d31b1b5e55a3f15a?ver=CBV2.0>
+        a                          epcis:AssociationEvent ;
+        epcis:action               "ADD" ;
+        epcis:bizStep              <urn:epcglobal:cbv:bizstep:assembling> ;
+        epcis:childEPCs            <urn:epc:id:giai:4000001.12345> ;
+        epcis:eventTime            "2019-11-01T14:00:00.000+01:00"^^xsd:dateTime ;
+        epcis:eventTimeZoneOffset  "+01:00" ;
+        epcis:parentID             <urn:epc:id:grai:4012345.55555.987> ;
+        epcis:readPoint            <urn:epc:id:sgln:4012345.00001.0> .
+
+[ a                epcis:EPCISDocument ;
+  dcterms:created  "2019-11-01T14:00:00.000+01:00"^^xsd:dateTime ;
+  dcterms:format   "application/ld+json" ;
+  owl:versionInfo  "2.0" ;
+  epcis:epcisBody  [ epcis:eventList  <ni:///sha-256;025ac144187a8c5e14caf4d1cfa69250a33dc59a5bc42a68d31b1b5e55a3f15a?ver=CBV2.0> ]
+] .

--- a/Turtle/AssociationEvent/AssociationEvent-a.ttl
+++ b/Turtle/AssociationEvent/AssociationEvent-a.ttl
@@ -1,12 +1,13 @@
 @prefix epcis: <https://ns.gs1.org/epcis/> .
 @prefix gs1:   <https://gs1.org/voc/> .
+@prefix example2: <http://epcis.example.com/ns/> .
 @prefix owl:   <http://www.w3.org/2002/07/owl#> .
 @prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix vtype: <urn:epcglobal:epcis:vtype:> .
 @prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix example1: <http://ns.example.com/epcis/> .
 @prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix example: <http://ns.example.com/epcis/> .
 @prefix cbvmda: <urn:epcglobal:cbv:mda:> .
 
 <ni:///sha-256;025ac144187a8c5e14caf4d1cfa69250a33dc59a5bc42a68d31b1b5e55a3f15a?ver=CBV2.0>

--- a/Turtle/AssociationEvent/AssociationEvent-b.ttl
+++ b/Turtle/AssociationEvent/AssociationEvent-b.ttl
@@ -1,0 +1,27 @@
+@prefix epcis: <https://ns.gs1.org/epcis/> .
+@prefix gs1:   <https://gs1.org/voc/> .
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix vtype: <urn:epcglobal:epcis:vtype:> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix example: <http://ns.example.com/epcis/> .
+@prefix cbvmda: <urn:epcglobal:cbv:mda:> .
+
+[ a                epcis:EPCISDocument ;
+  dcterms:created  "2019-11-02T14:00:00.000+01:00"^^xsd:dateTime ;
+  dcterms:format   "application/ld+json" ;
+  owl:versionInfo  "2.0" ;
+  epcis:epcisBody  [ epcis:eventList  <ni:///sha-256;a15e0b457cfc95305b6d530978c4cd7965bb29c0b8c312310fc7210c9ef123d9?ver=CBV2.0> ]
+] .
+
+<ni:///sha-256;a15e0b457cfc95305b6d530978c4cd7965bb29c0b8c312310fc7210c9ef123d9?ver=CBV2.0>
+        a                          epcis:AssociationEvent ;
+        epcis:action               "ADD" ;
+        epcis:bizStep              <urn:epcglobal:cbv:bizstep:installing> ;
+        epcis:childEPCs            <urn:epc:id:giai:4000001.12346> ;
+        epcis:eventTime            "2019-11-02T14:00:00.000+01:00"^^xsd:dateTime ;
+        epcis:eventTimeZoneOffset  "+01:00" ;
+        epcis:parentID             <urn:epc:id:sgln:4012345.00002.12> ;
+        epcis:readPoint            <urn:epc:id:sgln:4012345.00002.0> .

--- a/Turtle/AssociationEvent/AssociationEvent-c.ttl
+++ b/Turtle/AssociationEvent/AssociationEvent-c.ttl
@@ -1,0 +1,27 @@
+@prefix epcis: <https://ns.gs1.org/epcis/> .
+@prefix gs1:   <https://gs1.org/voc/> .
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix vtype: <urn:epcglobal:epcis:vtype:> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix example: <http://ns.example.com/epcis/> .
+@prefix cbvmda: <urn:epcglobal:cbv:mda:> .
+
+[ a                epcis:EPCISDocument ;
+  dcterms:created  "2019-11-03T14:00:00.000+01:00"^^xsd:dateTime ;
+  dcterms:format   "application/ld+json" ;
+  owl:versionInfo  "2.0" ;
+  epcis:epcisBody  [ epcis:eventList  <ni:///sha-256;371c8eb1834fe5bca8722458310287d40d046c5bf032a484a8274299f7be2f59?ver=CBV2.0> ]
+] .
+
+<ni:///sha-256;371c8eb1834fe5bca8722458310287d40d046c5bf032a484a8274299f7be2f59?ver=CBV2.0>
+        a                          epcis:AssociationEvent ;
+        epcis:action               "DELETE" ;
+        epcis:bizStep              <urn:epcglobal:cbv:bizstep:removing> ;
+        epcis:childEPCs            <urn:epc:id:giai:4000001.12345> ;
+        epcis:eventTime            "2019-11-03T14:00:00.000+01:00"^^xsd:dateTime ;
+        epcis:eventTimeZoneOffset  "+01:00" ;
+        epcis:parentID             <urn:epc:id:grai:4012345.55555.987> ;
+        epcis:readPoint            <urn:epc:id:sgln:4012345.00002.0> .

--- a/Turtle/AssociationEvent/AssociationEvent-d.ttl
+++ b/Turtle/AssociationEvent/AssociationEvent-d.ttl
@@ -1,0 +1,26 @@
+@prefix epcis: <https://ns.gs1.org/epcis/> .
+@prefix gs1:   <https://gs1.org/voc/> .
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix vtype: <urn:epcglobal:epcis:vtype:> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix example: <http://ns.example.com/epcis/> .
+@prefix cbvmda: <urn:epcglobal:cbv:mda:> .
+
+<ni:///sha-256;8a2d6f46deae4e62f517b2d2f84d2251b0c2db43b791663575e9ff358560fd85?ver=CBV2.0>
+        a                          epcis:AssociationEvent ;
+        epcis:action               "DELETE" ;
+        epcis:bizStep              <urn:epcglobal:cbv:bizstep:disassembling> ;
+        epcis:eventTime            "2019-11-04T14:00:00.000+01:00"^^xsd:dateTime ;
+        epcis:eventTimeZoneOffset  "+01:00" ;
+        epcis:parentID             <urn:epc:id:grai:4012345.55555.987> ;
+        epcis:readPoint            <urn:epc:id:sgln:4012345.00002.0> .
+
+[ a                epcis:EPCISDocument ;
+  dcterms:created  "2019-11-04T14:00:00.000+01:00"^^xsd:dateTime ;
+  dcterms:format   "application/ld+json" ;
+  owl:versionInfo  "2.0" ;
+  epcis:epcisBody  [ epcis:eventList  <ni:///sha-256;8a2d6f46deae4e62f517b2d2f84d2251b0c2db43b791663575e9ff358560fd85?ver=CBV2.0> ]
+] .

--- a/Turtle/AssociationEvent/AssociationEvent-e.ttl
+++ b/Turtle/AssociationEvent/AssociationEvent-e.ttl
@@ -1,0 +1,32 @@
+@prefix epcis: <https://ns.gs1.org/epcis/> .
+@prefix gs1:   <https://gs1.org/voc/> .
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix vtype: <urn:epcglobal:epcis:vtype:> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix example: <http://ns.example.com/epcis/> .
+@prefix cbvmda: <urn:epcglobal:cbv:mda:> .
+
+[ a                epcis:EPCISDocument ;
+  dcterms:created  "2019-11-05T14:00:00.000+01:00"^^xsd:dateTime ;
+  dcterms:format   "application/ld+json" ;
+  owl:versionInfo  "2.0" ;
+  epcis:epcisBody  [ epcis:eventList  <ni:///sha-256;8bbf932aa86072c4e5e6e58666b9344447c3811e07823677c336a00d7db67e5a?ver=CBV2.0> ]
+] .
+
+<ni:///sha-256;8bbf932aa86072c4e5e6e58666b9344447c3811e07823677c336a00d7db67e5a?ver=CBV2.0>
+        a                          epcis:AssociationEvent ;
+        epcis:action               "ADD" ;
+        epcis:bizStep              <urn:epcglobal:cbv:bizstep:assembling> ;
+        epcis:childQuantityList    [ epcis:epcClass  <urn:epc:class:lgtin:4012345.005555.456> ;
+                                     epcis:quantity  "600"^^xsd:decimal
+                                   ] ;
+        epcis:childQuantityList    [ epcis:epcClass  <urn:epc:class:lgtin:4023333.002000.123> ;
+                                     epcis:quantity  "600"^^xsd:decimal
+                                   ] ;
+        epcis:eventTime            "2019-11-05T14:00:00.000+01:00"^^xsd:dateTime ;
+        epcis:eventTimeZoneOffset  "+01:00" ;
+        epcis:parentID             <urn:epc:id:grai:4012345.55555.987> ;
+        epcis:readPoint            <urn:epc:id:sgln:4012345.00001.0> .

--- a/Turtle/AssociationEvent/AssociationEvent-f.ttl
+++ b/Turtle/AssociationEvent/AssociationEvent-f.ttl
@@ -1,0 +1,51 @@
+@prefix epcis: <https://ns.gs1.org/epcis/> .
+@prefix gs1:   <https://gs1.org/voc/> .
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix vtype: <urn:epcglobal:epcis:vtype:> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix example: <http://ns.example.com/epcis/> .
+@prefix cbvmda: <urn:epcglobal:cbv:mda:> .
+
+<ni:///sha-256;5f7c472bc4905de27a19b2efc8e4a9c6dc195139669b80b515f12218ff07cf65?ver=CBV2.0>
+        a                          epcis:AssociationEvent ;
+        epcis:action               "ADD" ;
+        epcis:bizLocation          <urn:epc:id:sgln:4012345.00002.0> ;
+        epcis:bizStep              <urn:epcglobal:cbv:bizstep:installing> ;
+        epcis:bizTransactionList   [ epcis:bizTransaction  <urn:epcglobal:cbv:bt:4023333000000:54545> ;
+                                     epcis:type            <urn:epcglobal:cbv:btt:inv>
+                                   ] ;
+        epcis:childEPCs            <urn:epc:id:giai:4000001.12345> , <urn:epc:id:giai:4000001.12346> ;
+        epcis:childQuantityList    [ epcis:epcClass  <urn:epc:class:lgtin:4023333.002000.998877> ;
+                                     epcis:quantity  "4"^^xsd:decimal
+                                   ] ;
+        epcis:destinationList      [ epcis:destination  <urn:epc:id:pgln:4012345.00000> ;
+                                     epcis:type         <urn:epcglobal:cbv:sdt:possessing_party>
+                                   ] ;
+        epcis:disposition          <urn:epcglobal:cbv:disp:in_progress> ;
+        epcis:eventTime            "2019-11-06T14:00:00.000+01:00"^^xsd:dateTime ;
+        epcis:eventTimeZoneOffset  "+01:00" ;
+        epcis:parentID             <urn:epc:id:grai:4012345.55555.98765> ;
+        epcis:readPoint            <urn:epc:id:sgln:4012345.00001.0> ;
+        epcis:recordTime           "2019-11-06T14:05:00.000+01:00"^^xsd:dateTime ;
+        epcis:sensorElementList    [ epcis:sensorMetadata  [ epcis:endTime    "2019-11-06T13:57:00.000+01:00"^^xsd:dateTime ;
+                                                             epcis:startTime  "2019-11-06T13:55:00.000+01:00"^^xsd:dateTime
+                                                           ] ;
+                                     epcis:sensorReport    [ epcis:maxValue  "1.22E1"^^xsd:float ;
+                                                             epcis:minValue  "1.21E1"^^xsd:float ;
+                                                             epcis:type      gs1:Humidity ;
+                                                             epcis:uom       "A93"
+                                                           ]
+                                   ] ;
+        epcis:sourceList           [ epcis:source  <urn:epc:id:pgln:4000001.00012> ;
+                                     epcis:type    <urn:epcglobal:cbv:sdt:possessing_party>
+                                   ] .
+
+[ a                epcis:EPCISDocument ;
+  dcterms:created  "2019-11-06T14:00:00.000+01:00"^^xsd:dateTime ;
+  dcterms:format   "application/ld+json" ;
+  owl:versionInfo  "2.0" ;
+  epcis:epcisBody  [ epcis:eventList  <ni:///sha-256;5f7c472bc4905de27a19b2efc8e4a9c6dc195139669b80b515f12218ff07cf65?ver=CBV2.0> ]
+] .

--- a/Turtle/AssociationEvent/AssociationEvent-g.ttl
+++ b/Turtle/AssociationEvent/AssociationEvent-g.ttl
@@ -1,0 +1,30 @@
+@prefix epcis: <https://ns.gs1.org/epcis/> .
+@prefix gs1:   <https://gs1.org/voc/> .
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix vtype: <urn:epcglobal:epcis:vtype:> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix example: <http://ns.example.com/epcis/> .
+@prefix cbvmda: <urn:epcglobal:cbv:mda:> .
+
+<ni:///sha-256;3acf0f5d06f13134ea8899b9a711eb4d4039dfefd73f2093136729296d904d9a?ver=CBV2.0>
+        a                          epcis:AssociationEvent ;
+        epcis:action               "DELETE" ;
+        epcis:bizStep              <urn:epcglobal:cbv:bizstep:disassembling> ;
+        epcis:errorDeclaration     [ epcis:correctiveEventIDs  <urn:uuid:fd338495-0e6d-41dd-afee-a862ecd32518> ;
+                                     epcis:declarationTime     "2019-11-07T14:00:00.000+01:00"^^xsd:dateTime ;
+                                     epcis:reason              <urn:epcglobal:cbv:er:incorrect_data>
+                                   ] ;
+        epcis:eventTime            "2019-11-04T14:00:00.000+01:00"^^xsd:dateTime ;
+        epcis:eventTimeZoneOffset  "+01:00" ;
+        epcis:parentID             <urn:epc:id:grai:4012345.55555.987> ;
+        epcis:readPoint            <urn:epc:id:sgln:4012345.00002.0> .
+
+[ a                epcis:EPCISDocument ;
+  dcterms:created  "2019-11-04T14:00:00.000+01:00"^^xsd:dateTime ;
+  dcterms:format   "application/ld+json" ;
+  owl:versionInfo  "2.0" ;
+  epcis:epcisBody  [ epcis:eventList  <ni:///sha-256;3acf0f5d06f13134ea8899b9a711eb4d4039dfefd73f2093136729296d904d9a?ver=CBV2.0> ]
+] .

--- a/Turtle/AssociationEvent/AssociationEvent-h.ttl
+++ b/Turtle/AssociationEvent/AssociationEvent-h.ttl
@@ -1,0 +1,27 @@
+@prefix epcis: <https://ns.gs1.org/epcis/> .
+@prefix gs1:   <https://gs1.org/voc/> .
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix vtype: <urn:epcglobal:epcis:vtype:> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix example: <http://ns.example.com/epcis/> .
+@prefix cbvmda: <urn:epcglobal:cbv:mda:> .
+
+[ a                epcis:EPCISDocument ;
+  dcterms:created  "2019-11-04T14:00:00.000+01:00"^^xsd:dateTime ;
+  dcterms:format   "application/ld+json" ;
+  owl:versionInfo  "2.0" ;
+  epcis:epcisBody  [ epcis:eventList  <urn:uuid:fd338495-0e6d-41dd-afee-a862ecd32518> ]
+] .
+
+<urn:uuid:fd338495-0e6d-41dd-afee-a862ecd32518>
+        a                          epcis:AssociationEvent ;
+        epcis:action               "DELETE" ;
+        epcis:bizStep              <urn:epcglobal:cbv:bizstep:disassembling> ;
+        epcis:childEPCs            <urn:epc:id:giai:4000001.12346> , <urn:epc:id:giai:4000001.12345> ;
+        epcis:eventTime            "2019-11-04T14:00:00.000+01:00"^^xsd:dateTime ;
+        epcis:eventTimeZoneOffset  "+01:00" ;
+        epcis:parentID             <urn:epc:id:grai:4012345.55555.987> ;
+        epcis:readPoint            <urn:epc:id:sgln:4012345.00002.0> .

--- a/Turtle/Example_9.6.1-ObjectEvent-with-error-declaration.ttl
+++ b/Turtle/Example_9.6.1-ObjectEvent-with-error-declaration.ttl
@@ -1,0 +1,52 @@
+@prefix epcis: <https://ns.gs1.org/epcis/> .
+@prefix gs1:   <https://gs1.org/voc/> .
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix vtype: <urn:epcglobal:epcis:vtype:> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix example: <http://ns.example.com/epcis/> .
+@prefix cbvmda: <urn:epcglobal:cbv:mda:> .
+
+<ni:///sha-256;00e1e6eba3a7cc6125be4793a631f0af50f8322e0ab5f2c0bab994a11cec1d79?ver=CBV2.0>
+        a                          epcis:ObjectEvent ;
+        example:myField            "Example of a vendor/user extension" ;
+        epcis:action               "OBSERVE" ;
+        epcis:bizLocation          <urn:epc:id:sgln:0012345.11111.0> ;
+        epcis:bizStep              <urn:epcglobal:cbv:bizstep:receiving> ;
+        epcis:bizTransactionList   [ epcis:bizTransaction  <http://transaction.acme.com/po/12345678> ;
+                                     epcis:type            <urn:epcglobal:cbv:btt:po>
+                                   ] ;
+        epcis:bizTransactionList   [ epcis:bizTransaction  <urn:epcglobal:cbv:bt:0614141073467:1152> ;
+                                     epcis:type            <urn:epcglobal:cbv:btt:desadv>
+                                   ] ;
+        epcis:disposition          <urn:epcglobal:cbv:disp:in_progress> ;
+        epcis:epcList              <urn:epc:id:sgtin:0614141.107346.2018> ;
+        epcis:eventTime            "2005-04-04T20:33:31.116-06:00"^^xsd:dateTime ;
+        epcis:eventTimeZoneOffset  "-06:00" ;
+        epcis:readPoint            <urn:epc:id:sgln:0012345.11111.400> .
+
+[ a                epcis:EPCISDocument ;
+  dcterms:created  "2005-07-11T11:30:47.0Z"^^xsd:dateTime ;
+  dcterms:format   "application/ld+json" ;
+  owl:versionInfo  "2.0" ;
+  epcis:epcisBody  [ epcis:eventList  <ni:///sha-256;aa49daa1fe0b773e0437e546078dc87de9c864d5b9babe84488f31478887fdf3?ver=CBV2.0> , <ni:///sha-256;00e1e6eba3a7cc6125be4793a631f0af50f8322e0ab5f2c0bab994a11cec1d79?ver=CBV2.0> ]
+] .
+
+<ni:///sha-256;aa49daa1fe0b773e0437e546078dc87de9c864d5b9babe84488f31478887fdf3?ver=CBV2.0>
+        a                          epcis:ObjectEvent ;
+        epcis:action               "OBSERVE" ;
+        epcis:bizStep              <urn:epcglobal:cbv:bizstep:shipping> ;
+        epcis:bizTransactionList   [ epcis:bizTransaction  <http://transaction.acme.com/po/12345678> ;
+                                     epcis:type            <urn:epcglobal:cbv:btt:po>
+                                   ] ;
+        epcis:disposition          <urn:epcglobal:cbv:disp:in_transit> ;
+        epcis:epcList              <urn:epc:id:sgtin:0614141.107346.2018> , <urn:epc:id:sgtin:0614141.107346.2017> ;
+        epcis:errorDeclaration     [ epcis:correctiveEventIDs  <urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6> , <ni:///sha-256;c6407ffcac52ec159528f2b556ba4ac3844c5aa48485c1fd61643e94f0a2d678?ver=CBV2.0> ;
+                                     epcis:declarationTime     "2021-02-01T22:46:31.117000+00:00"^^xsd:dateTime ;
+                                     epcis:reason              <urn:epcglobal:cbv:er:incorrect-data>
+                                   ] ;
+        epcis:eventTime            "2005-04-03T20:33:31.116000-06:00"^^xsd:dateTime ;
+        epcis:eventTimeZoneOffset  "-06:00" ;
+        epcis:readPoint            <urn:epc:id:sgln:0614141.07346.1234> .

--- a/Turtle/Example_9.6.1-ObjectEvent.ttl
+++ b/Turtle/Example_9.6.1-ObjectEvent.ttl
@@ -1,0 +1,48 @@
+@prefix epcis: <https://ns.gs1.org/epcis/> .
+@prefix gs1:   <https://gs1.org/voc/> .
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix vtype: <urn:epcglobal:epcis:vtype:> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix example: <http://ns.example.com/epcis/> .
+@prefix cbvmda: <urn:epcglobal:cbv:mda:> .
+
+<ni:///sha-256;00e1e6eba3a7cc6125be4793a631f0af50f8322e0ab5f2c0bab994a11cec1d79?ver=CBV2.0>
+        a                          epcis:ObjectEvent ;
+        example:myField            "Example of a vendor/user extension" ;
+        epcis:action               "OBSERVE" ;
+        epcis:bizLocation          <urn:epc:id:sgln:0012345.11111.0> ;
+        epcis:bizStep              <urn:epcglobal:cbv:bizstep:receiving> ;
+        epcis:bizTransactionList   [ epcis:bizTransaction  <http://transaction.acme.com/po/12345678> ;
+                                     epcis:type            <urn:epcglobal:cbv:btt:po>
+                                   ] ;
+        epcis:bizTransactionList   [ epcis:bizTransaction  <urn:epcglobal:cbv:bt:0614141073467:1152> ;
+                                     epcis:type            <urn:epcglobal:cbv:btt:desadv>
+                                   ] ;
+        epcis:disposition          <urn:epcglobal:cbv:disp:in_progress> ;
+        epcis:epcList              <urn:epc:id:sgtin:0614141.107346.2018> ;
+        epcis:eventTime            "2005-04-04T20:33:31.116-06:00"^^xsd:dateTime ;
+        epcis:eventTimeZoneOffset  "-06:00" ;
+        epcis:readPoint            <urn:epc:id:sgln:0012345.11111.400> .
+
+<ni:///sha-256;df7bb3c352fef055578554f09f5e2aa41782150ced7bd0b8af24dd3ccb30ba69?ver=CBV2.0>
+        a                          epcis:ObjectEvent ;
+        epcis:action               "OBSERVE" ;
+        epcis:bizStep              <urn:epcglobal:cbv:bizstep:shipping> ;
+        epcis:bizTransactionList   [ epcis:bizTransaction  <http://transaction.acme.com/po/12345678> ;
+                                     epcis:type            <urn:epcglobal:cbv:btt:po>
+                                   ] ;
+        epcis:disposition          <urn:epcglobal:cbv:disp:in_transit> ;
+        epcis:epcList              <urn:epc:id:sgtin:0614141.107346.2018> , <urn:epc:id:sgtin:0614141.107346.2017> ;
+        epcis:eventTime            "2005-04-03T20:33:31.116000-06:00"^^xsd:dateTime ;
+        epcis:eventTimeZoneOffset  "-06:00" ;
+        epcis:readPoint            <urn:epc:id:sgln:0614141.07346.1234> .
+
+[ a                epcis:EPCISDocument ;
+  dcterms:created  "2005-07-11T11:30:47.0Z"^^xsd:dateTime ;
+  dcterms:format   "application/ld+json" ;
+  owl:versionInfo  "2.0" ;
+  epcis:epcisBody  [ epcis:eventList  <ni:///sha-256;df7bb3c352fef055578554f09f5e2aa41782150ced7bd0b8af24dd3ccb30ba69?ver=CBV2.0> , <ni:///sha-256;00e1e6eba3a7cc6125be4793a631f0af50f8322e0ab5f2c0bab994a11cec1d79?ver=CBV2.0> ]
+] .

--- a/Turtle/Example_9.6.1-with-comment.ttl
+++ b/Turtle/Example_9.6.1-with-comment.ttl
@@ -1,0 +1,46 @@
+@prefix epcis: <https://ns.gs1.org/epcis/> .
+@prefix gs1:   <https://gs1.org/voc/> .
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix vtype: <urn:epcglobal:epcis:vtype:> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix example: <http://ns.example.com/epcis/> .
+@prefix cbvmda: <urn:epcglobal:cbv:mda:> .
+
+[ a                epcis:EPCISDocument ;
+  dcterms:created  "2005-07-11T11:30:47.0Z"^^xsd:dateTime ;
+  dcterms:format   "application/ld+json" ;
+  owl:versionInfo  "2.0" ;
+  epcis:epcisBody  [ epcis:eventList  [ a                          epcis:ObjectEvent ;
+                                        example:myField            "Example of a vendor/user extension" ;
+                                        epcis:action               "OBSERVE" ;
+                                        epcis:bizLocation          <urn:epc:id:sgln:0012345.11111.0> ;
+                                        epcis:bizStep              <urn:epcglobal:cbv:bizstep:receiving> ;
+                                        epcis:bizTransactionList   [ epcis:bizTransaction  <http://transaction.acme.com/po/12345678> ;
+                                                                     epcis:type            <urn:epcglobal:cbv:btt:po>
+                                                                   ] ;
+                                        epcis:bizTransactionList   [ epcis:bizTransaction  <urn:epcglobal:cbv:bt:0614141073467:1152> ;
+                                                                     epcis:type            <urn:epcglobal:cbv:btt:desadv>
+                                                                   ] ;
+                                        epcis:disposition          <urn:epcglobal:cbv:disp:in_progress> ;
+                                        epcis:epcList              <urn:epc:id:sgtin:0614141.107346.2018> ;
+                                        epcis:eventTime            "2005-04-04T20:33:31.116-06:00"^^xsd:dateTime ;
+                                        epcis:eventTimeZoneOffset  "-06:00" ;
+                                        epcis:readPoint            <urn:epc:id:sgln:0012345.11111.400>
+                                      ] ;
+            epcis:eventList  [ a                          epcis:ObjectEvent ;
+                               rdfs:comment               "An ObjectEvent may be used for reporting an observation" ;
+                               epcis:action               "OBSERVE" ;
+                               epcis:bizStep              <urn:epcglobal:cbv:bizstep:shipping> ;
+                               epcis:bizTransactionList   [ epcis:bizTransaction  <http://transaction.acme.com/po/12345678> ;
+                                                            epcis:type            <urn:epcglobal:cbv:btt:po>
+                                                          ] ;
+                               epcis:disposition          <urn:epcglobal:cbv:disp:in_transit> ;
+                               epcis:epcList              <urn:epc:id:sgtin:0614141.107346.2018> , <urn:epc:id:sgtin:0614141.107346.2017> ;
+                               epcis:eventTime            "2005-04-03T20:33:31.116000-06:00"^^xsd:dateTime ;
+                               epcis:eventTimeZoneOffset  "-06:00" ;
+                               epcis:readPoint            <urn:epc:id:sgln:0614141.07346.1234>
+                             ] ]
+] .

--- a/Turtle/Example_9.6.2-ObjectEvent.ttl
+++ b/Turtle/Example_9.6.2-ObjectEvent.ttl
@@ -1,0 +1,44 @@
+@prefix epcis: <https://ns.gs1.org/epcis/> .
+@prefix gs1:   <https://gs1.org/voc/> .
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix vtype: <urn:epcglobal:epcis:vtype:> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix example: <http://ns.example.com/epcis/> .
+@prefix cbvmda: <urn:epcglobal:cbv:mda:> .
+
+<ni:///sha-256;a98f08ae6ac4de3482054314d637c07010b448d3802dccb028a06aafcc6a4b10?ver=CBV2.0>
+        a                          epcis:ObjectEvent ;
+        example:myField            "Example of a vendor/user extension" ;
+        epcis:action               "OBSERVE" ;
+        epcis:bizLocation          <urn:epc:id:sgln:0614141.00888.0> ;
+        epcis:bizStep              <urn:epcglobal:cbv:bizstep:receiving> ;
+        epcis:destinationList      [ epcis:destination  <urn:epc:id:sgln:0614141.00001.0> ;
+                                     epcis:type         <urn:epcglobal:cbv:sdt:owning_party>
+                                   ] ;
+        epcis:destinationList      [ epcis:destination  <urn:epc:id:sgln:0614141.00777.0> ;
+                                     epcis:type         <urn:epcglobal:cbv:sdt:location>
+                                   ] ;
+        epcis:disposition          <urn:epcglobal:cbv:disp:in_progress> ;
+        epcis:eventTime            "2013-06-08T14:58:56.591Z"^^xsd:dateTime ;
+        epcis:eventTimeZoneOffset  "+02:00" ;
+        epcis:quantityList         [ epcis:epcClass  <urn:epc:class:lgtin:4012345.012345.998877> ;
+                                     epcis:quantity  "200"^^xsd:decimal ;
+                                     epcis:uom       "KGM"
+                                   ] ;
+        epcis:readPoint            <urn:epc:id:sgln:0614141.00777.0> ;
+        epcis:sourceList           [ epcis:source  <urn:epc:id:sgln:4012345.00225.0> ;
+                                     epcis:type    <urn:epcglobal:cbv:sdt:location>
+                                   ] ;
+        epcis:sourceList           [ epcis:source  <urn:epc:id:sgln:4012345.00001.0> ;
+                                     epcis:type    <urn:epcglobal:cbv:sdt:possessing_party>
+                                   ] .
+
+[ a                epcis:EPCISDocument ;
+  dcterms:created  "2005-07-11T11:30:47.0Z"^^xsd:dateTime ;
+  dcterms:format   "application/ld+json" ;
+  owl:versionInfo  "2.0" ;
+  epcis:epcisBody  [ epcis:eventList  <ni:///sha-256;a98f08ae6ac4de3482054314d637c07010b448d3802dccb028a06aafcc6a4b10?ver=CBV2.0> ]
+] .

--- a/Turtle/Example_9.6.3-AggregationEvent.ttl
+++ b/Turtle/Example_9.6.3-AggregationEvent.ttl
@@ -1,0 +1,37 @@
+@prefix epcis: <https://ns.gs1.org/epcis/> .
+@prefix gs1:   <https://gs1.org/voc/> .
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix vtype: <urn:epcglobal:epcis:vtype:> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix example: <http://ns.example.com/epcis/> .
+@prefix cbvmda: <urn:epcglobal:cbv:mda:> .
+
+<ni:///sha-256;87b5f18a69993f0052046d4687dfacdf48f7c988cfabda2819688c86b4066a49?ver=CBV2.0>
+        a                          epcis:AggregationEvent ;
+        example:myField            "Example of a vendor/user extension" ;
+        epcis:action               "OBSERVE" ;
+        epcis:bizLocation          <urn:epc:id:sgln:0614141.00888.0> ;
+        epcis:bizStep              <urn:epcglobal:cbv:bizstep:receiving> ;
+        epcis:childEPCs            <urn:epc:id:sgtin:0614141.107346.2018> , <urn:epc:id:sgtin:0614141.107346.2017> ;
+        epcis:childQuantityList    [ epcis:epcClass  <urn:epc:idpat:sgtin:4012345.098765.*> ;
+                                     epcis:quantity  "10"^^xsd:decimal
+                                   ] ;
+        epcis:childQuantityList    [ epcis:epcClass  <urn:epc:class:lgtin:4012345.012345.998877> ;
+                                     epcis:quantity  "2.005E2"^^xsd:decimal ;
+                                     epcis:uom       "KGM"
+                                   ] ;
+        epcis:disposition          <urn:epcglobal:cbv:disp:in_progress> ;
+        epcis:eventTime            "2013-06-08T14:58:56.591Z"^^xsd:dateTime ;
+        epcis:eventTimeZoneOffset  "+02:00" ;
+        epcis:parentID             <urn:epc:id:sscc:0614141.1234567890> ;
+        epcis:readPoint            <urn:epc:id:sgln:0614141.00777.0> .
+
+[ a                epcis:EPCISDocument ;
+  dcterms:created  "2005-07-11T11:30:47.0Z"^^xsd:dateTime ;
+  dcterms:format   "application/ld+json" ;
+  owl:versionInfo  "2.0" ;
+  epcis:epcisBody  [ epcis:eventList  <ni:///sha-256;87b5f18a69993f0052046d4687dfacdf48f7c988cfabda2819688c86b4066a49?ver=CBV2.0> ]
+] .

--- a/Turtle/Example_9.6.4-TransformationEvent.ttl
+++ b/Turtle/Example_9.6.4-TransformationEvent.ttl
@@ -1,0 +1,41 @@
+@prefix epcis: <https://ns.gs1.org/epcis/> .
+@prefix gs1:   <https://gs1.org/voc/> .
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix vtype: <urn:epcglobal:epcis:vtype:> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix example: <http://ns.example.com/epcis/> .
+@prefix cbvmda: <urn:epcglobal:cbv:mda:> .
+
+[ a                epcis:EPCISDocument ;
+  dcterms:created  "2013-06-04T14:59:02.099+02:00"^^xsd:dateTime ;
+  dcterms:format   "application/ld+json" ;
+  owl:versionInfo  "2.0" ;
+  epcis:epcisBody  [ epcis:eventList  <ni:///sha-256;e65c3a997e77f34b58306da7a82ab0fc91c7820013287700f0b50345e5795b97?ver=CBV2.0> ]
+] .
+
+<ni:///sha-256;e65c3a997e77f34b58306da7a82ab0fc91c7820013287700f0b50345e5795b97?ver=CBV2.0>
+        a                          epcis:TransformationEvent ;
+        example:myField            "Example of a vendor/user extension" ;
+        epcis:bizStep              <urn:epcglobal:cbv:bizstep:commissioning> ;
+        epcis:disposition          <urn:epcglobal:cbv:disp:in_progress> ;
+        epcis:eventTime            "2013-10-31T14:58:56.591Z"^^xsd:dateTime ;
+        epcis:eventTimeZoneOffset  "+02:00" ;
+        epcis:ilmd                 [ example:batch           "XYZ" ;
+                                     example:bestBeforeDate  "2014-12-10"
+                                   ] ;
+        epcis:inputEPCList         <urn:epc:id:sgtin:4000001.065432.99886655> , <urn:epc:id:sgtin:4012345.011122.25> ;
+        epcis:inputQuantityList    [ epcis:epcClass  <urn:epc:idpat:sgtin:4012345.066666.*> ;
+                                     epcis:quantity  "220"^^xsd:decimal
+                                   ] ;
+        epcis:inputQuantityList    [ epcis:epcClass  <urn:epc:class:lgtin:4012345.011111.4444> ;
+                                     epcis:quantity  "10"^^xsd:decimal ;
+                                     epcis:uom       "KGM"
+                                   ] ;
+        epcis:inputQuantityList    [ epcis:epcClass  <urn:epc:class:lgtin:0614141.077777.987> ;
+                                     epcis:quantity  "30"^^xsd:decimal
+                                   ] ;
+        epcis:outputEPCList        <urn:epc:id:sgtin:4012345.077889.28> , <urn:epc:id:sgtin:4012345.077889.25> , <urn:epc:id:sgtin:4012345.077889.26> , <urn:epc:id:sgtin:4012345.077889.27> ;
+        epcis:readPoint            <urn:epc:id:sgln:4012345.00001.0> .

--- a/Turtle/Example_9.8.1-MasterData-complying-with-schema.ttl
+++ b/Turtle/Example_9.8.1-MasterData-complying-with-schema.ttl
@@ -1,26 +1,23 @@
 @prefix epcis: <https://ns.gs1.org/epcis/> .
 @prefix gs1:   <https://gs1.org/voc/> .
+@prefix example2: <http://epcis.example.com/ns/> .
 @prefix owl:   <http://www.w3.org/2002/07/owl#> .
 @prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix vtype: <urn:epcglobal:epcis:vtype:> .
 @prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix example1: <http://ns.example.com/epcis/> .
 @prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix example: <http://ns.example.com/epcis/> .
 @prefix cbvmda: <urn:epcglobal:cbv:mda:> .
 
 cbvmda:site  epcis:attribute  "0037000007296" .
 
 <http://epcis.example.com/mdaaddress>
-        epcis:attribute  [ a       <http://epcis.example.com/ns/Address> ;
-                           <http://epcis.example.com/ns/city>
-                                   "Fancy" ;
-                           <http://epcis.example.com/ns/state>
-                                   "DC" ;
-                           <http://epcis.example.com/ns/street>
-                                   "100 Nowhere Street" ;
-                           <http://epcis.example.com/ns/zip>
-                                   "99999"
+        epcis:attribute  [ a                example2:Address ;
+                           example2:city    "Fancy" ;
+                           example2:state   "DC" ;
+                           example2:street  "100 Nowhere Street" ;
+                           example2:zip     "99999"
                          ] .
 
 <urn:epc:id:sgln:0037000.00729.8201>
@@ -29,6 +26,14 @@ cbvmda:site  epcis:attribute  "0037000007296" .
 
 <http://epcis.example.com/mdalongitude>
         epcis:attribute  "-70.0000" .
+
+<urn:epc:id:sgln:0037000.00729.8202>
+        a                 vtype:ReadPoint , vtype:BusinessLocation ;
+        epcis:attributes  cbvmda:sst , cbvmda:site ;
+        epcis:children    <urn:epc:id:sgln:0037000.00729.8203> .
+
+<http://epcis.example.com/mdalatitude>
+        epcis:attribute  "+18.0000" .
 
 [ a                  epcis:EPCISDocument ;
   dcterms:created    "2005-07-11T11:30:47.0Z"^^xsd:dateTime ;
@@ -41,14 +46,6 @@ cbvmda:site  epcis:attribute  "0037000007296" .
                       epcis:vocabularyList  [ epcis:vocabularyElementList
                                         <urn:epc:id:sgln:0037000.00729.8203> , <urn:epc:id:sgln:0037000.00729.8202> , <urn:epc:id:sgln:0037000.00729.0> ] ] ]
 ] .
-
-<urn:epc:id:sgln:0037000.00729.8202>
-        a                 vtype:ReadPoint , vtype:BusinessLocation ;
-        epcis:attributes  cbvmda:sst , cbvmda:site ;
-        epcis:children    <urn:epc:id:sgln:0037000.00729.8203> .
-
-<http://epcis.example.com/mdalatitude>
-        epcis:attribute  "+18.0000" .
 
 <urn:epc:id:sgln:0037000.00729.0>
         a                 vtype:BusinessLocation ;

--- a/Turtle/Example_9.8.1-MasterData-complying-with-schema.ttl
+++ b/Turtle/Example_9.8.1-MasterData-complying-with-schema.ttl
@@ -1,0 +1,64 @@
+@prefix epcis: <https://ns.gs1.org/epcis/> .
+@prefix gs1:   <https://gs1.org/voc/> .
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix vtype: <urn:epcglobal:epcis:vtype:> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix example: <http://ns.example.com/epcis/> .
+@prefix cbvmda: <urn:epcglobal:cbv:mda:> .
+
+cbvmda:site  epcis:attribute  "0037000007296" .
+
+<http://epcis.example.com/mdaaddress>
+        epcis:attribute  [ a       <http://epcis.example.com/ns/Address> ;
+                           <http://epcis.example.com/ns/city>
+                                   "Fancy" ;
+                           <http://epcis.example.com/ns/state>
+                                   "DC" ;
+                           <http://epcis.example.com/ns/street>
+                                   "100 Nowhere Street" ;
+                           <http://epcis.example.com/ns/zip>
+                                   "99999"
+                         ] .
+
+<urn:epc:id:sgln:0037000.00729.8201>
+        a                 vtype:ReadPoint ;
+        epcis:attributes  cbvmda:sst , cbvmda:site .
+
+<http://epcis.example.com/mdalongitude>
+        epcis:attribute  "-70.0000" .
+
+[ a                  epcis:EPCISDocument ;
+  dcterms:created    "2005-07-11T11:30:47.0Z"^^xsd:dateTime ;
+  dcterms:format     "application/ld+json" ;
+  owl:versionInfo    "2.0" ;
+  epcis:epcisBody    []  ;
+  epcis:epcisHeader  [ epcis:epcisMasterData
+                    [ epcis:vocabularyList  [ epcis:vocabularyElementList
+                                        <urn:epc:id:sgln:0037000.00729.8203> , <urn:epc:id:sgln:0037000.00729.8202> , <urn:epc:id:sgln:0037000.00729.8201> ] ;
+                      epcis:vocabularyList  [ epcis:vocabularyElementList
+                                        <urn:epc:id:sgln:0037000.00729.8203> , <urn:epc:id:sgln:0037000.00729.8202> , <urn:epc:id:sgln:0037000.00729.0> ] ] ]
+] .
+
+<urn:epc:id:sgln:0037000.00729.8202>
+        a                 vtype:ReadPoint , vtype:BusinessLocation ;
+        epcis:attributes  cbvmda:sst , cbvmda:site ;
+        epcis:children    <urn:epc:id:sgln:0037000.00729.8203> .
+
+<http://epcis.example.com/mdalatitude>
+        epcis:attribute  "+18.0000" .
+
+<urn:epc:id:sgln:0037000.00729.0>
+        a                 vtype:BusinessLocation ;
+        epcis:attributes  <http://epcis.example.com/mdalongitude> , <http://epcis.example.com/mdalatitude> , <http://epcis.example.com/mdaaddress> ;
+        epcis:children    <urn:epc:id:sgln:0037000.00729.8203> , <urn:epc:id:sgln:0037000.00729.8202> , <urn:epc:id:sgln:0037000.00729.8201> .
+
+cbvmda:sst  epcis:attribute  204 , "202" , 201 .
+
+<urn:epc:id:sgln:0037000.00729.8203>
+        a                 vtype:ReadPoint , vtype:BusinessLocation ;
+        epcis:attributes  cbvmda:sst , cbvmda:ssa .
+
+cbvmda:ssa  epcis:attribute  "402" .

--- a/Turtle/Example_9.8.1-MasterData-complying-with-schema.ttl
+++ b/Turtle/Example_9.8.1-MasterData-complying-with-schema.ttl
@@ -1,9 +1,11 @@
 @prefix epcis: <https://ns.gs1.org/epcis/> .
 @prefix gs1:   <https://gs1.org/voc/> .
 @prefix example2: <http://epcis.example.com/ns/> .
-@prefix owl:   <http://www.w3.org/2002/07/owl#> .
 @prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix vtype: <urn:epcglobal:epcis:vtype:> .
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix md:    <https://ns.gs1.org/epcismd/> .
+@prefix example-mda: <http://epcis.example.com/mda/> .
 @prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix example1: <http://ns.example.com/epcis/> .
@@ -27,18 +29,10 @@ cbvmda:site  epcis:attribute  "0037000007296" .
 <http://epcis.example.com/mdalongitude>
         epcis:attribute  "-70.0000" .
 
-<urn:epc:id:sgln:0037000.00729.8202>
-        a                 vtype:ReadPoint , vtype:BusinessLocation ;
-        epcis:attributes  cbvmda:sst , cbvmda:site ;
-        epcis:children    <urn:epc:id:sgln:0037000.00729.8203> .
-
-<http://epcis.example.com/mdalatitude>
-        epcis:attribute  "+18.0000" .
-
 [ a                  epcis:EPCISDocument ;
   dcterms:created    "2005-07-11T11:30:47.0Z"^^xsd:dateTime ;
   dcterms:format     "application/ld+json" ;
-  owl:versionInfo    "2.0" ;
+  owl:versionInfo    "2" ;
   epcis:epcisBody    []  ;
   epcis:epcisHeader  [ epcis:epcisMasterData
                     [ epcis:vocabularyList  [ epcis:vocabularyElementList
@@ -46,6 +40,14 @@ cbvmda:site  epcis:attribute  "0037000007296" .
                       epcis:vocabularyList  [ epcis:vocabularyElementList
                                         <urn:epc:id:sgln:0037000.00729.8203> , <urn:epc:id:sgln:0037000.00729.8202> , <urn:epc:id:sgln:0037000.00729.0> ] ] ]
 ] .
+
+<urn:epc:id:sgln:0037000.00729.8202>
+        a                 vtype:ReadPoint , vtype:BusinessLocation ;
+        epcis:attributes  cbvmda:sst , cbvmda:site ;
+        epcis:children    <urn:epc:id:sgln:0037000.00729.8203> .
+
+<http://epcis.example.com/mdalatitude>
+        epcis:attribute  "+18.0000" .
 
 <urn:epc:id:sgln:0037000.00729.0>
         a                 vtype:BusinessLocation ;

--- a/Turtle/Example_9.8.1-MasterData.ttl
+++ b/Turtle/Example_9.8.1-MasterData.ttl
@@ -1,18 +1,37 @@
 @prefix epcis: <https://ns.gs1.org/epcis/> .
 @prefix gs1:   <https://gs1.org/voc/> .
+@prefix example2: <http://epcis.example.com/ns/> .
 @prefix owl:   <http://www.w3.org/2002/07/owl#> .
 @prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix vtype: <urn:epcglobal:epcis:vtype:> .
 @prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix example1: <http://ns.example.com/epcis/> .
 @prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix example: <http://ns.example.com/epcis/> .
 @prefix cbvmda: <urn:epcglobal:cbv:mda:> .
 
 <urn:epc:id:sgln:0037000.00729.8201>
         a            epcis:VocabularyElement ;
         cbvmda:site  "0037000007296" ;
         cbvmda:sst   201 , "201" .
+
+<urn:epc:id:sgln:0037000.00729.8202>
+        a               epcis:VocabularyElement ;
+        epcis:children  <urn:epc:id:sgln:0037000.00729.8203> ;
+        cbvmda:site     "0037000007296" ;
+        cbvmda:sst      202 , "202" .
+
+<urn:epc:id:sgln:0037000.00729.0>
+        a                 epcis:VocabularyElement ;
+        epcis:children    <urn:epc:id:sgln:0037000.00729.8203> , <urn:epc:id:sgln:0037000.00729.8202> , <urn:epc:id:sgln:0037000.00729.8201> ;
+        <xmda:address>    [ a                example2:Address ;
+                            example2:city    "Fancy" ;
+                            example2:state   "DC" ;
+                            example2:street  "100 Nowhere Street" ;
+                            example2:zip     "99999"
+                          ] ;
+        <xmda:latitude>   "+18:0000" ;
+        <xmda:longitude>  "-70.0000" .
 
 [ a                epcis:EPCISMasterDataDocument ;
   dcterms:created  "2005-07-11T11:30:47.0Z"^^xsd:dateTime ;
@@ -27,28 +46,6 @@
                                     epcis:vocabularyElementList  <urn:epc:id:sgln:0037000.00729.8203> , <urn:epc:id:sgln:0037000.00729.8202> , <urn:epc:id:sgln:0037000.00729.8201> , <urn:epc:id:sgln:0037000.00729.0>
                                   ] ]
 ] .
-
-<urn:epc:id:sgln:0037000.00729.8202>
-        a               epcis:VocabularyElement ;
-        epcis:children  <urn:epc:id:sgln:0037000.00729.8203> ;
-        cbvmda:site     "0037000007296" ;
-        cbvmda:sst      202 , "202" .
-
-<urn:epc:id:sgln:0037000.00729.0>
-        a                 epcis:VocabularyElement ;
-        epcis:children    <urn:epc:id:sgln:0037000.00729.8203> , <urn:epc:id:sgln:0037000.00729.8202> , <urn:epc:id:sgln:0037000.00729.8201> ;
-        <xmda:address>    [ a       <http://epcis.example.com/ns/Address> ;
-                            <http://epcis.example.com/ns/city>
-                                    "Fancy" ;
-                            <http://epcis.example.com/ns/state>
-                                    "DC" ;
-                            <http://epcis.example.com/ns/street>
-                                    "100 Nowhere Street" ;
-                            <http://epcis.example.com/ns/zip>
-                                    "99999"
-                          ] ;
-        <xmda:latitude>   "+18:0000" ;
-        <xmda:longitude>  "-70.0000" .
 
 <urn:epc:id:sgln:0037000.00729.8203>
         a           epcis:VocabularyElement ;

--- a/Turtle/Example_9.8.1-MasterData.ttl
+++ b/Turtle/Example_9.8.1-MasterData.ttl
@@ -1,0 +1,56 @@
+@prefix epcis: <https://ns.gs1.org/epcis/> .
+@prefix gs1:   <https://gs1.org/voc/> .
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix vtype: <urn:epcglobal:epcis:vtype:> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix example: <http://ns.example.com/epcis/> .
+@prefix cbvmda: <urn:epcglobal:cbv:mda:> .
+
+<urn:epc:id:sgln:0037000.00729.8201>
+        a            epcis:VocabularyElement ;
+        cbvmda:site  "0037000007296" ;
+        cbvmda:sst   201 , "201" .
+
+[ a                epcis:EPCISMasterDataDocument ;
+  dcterms:created  "2005-07-11T11:30:47.0Z"^^xsd:dateTime ;
+  dcterms:format   "application/ld+json" ;
+  owl:versionInfo  "2.0" ;
+  epcis:epcisBody  [ epcis:vocabularyList  [ a                            epcis:Vocabulary ;
+                                             epcis:type                   vtype:ReadPoint ;
+                                             epcis:vocabularyElementList  <urn:epc:id:sgln:0037000.00729.8203> , <urn:epc:id:sgln:0037000.00729.8202> , <urn:epc:id:sgln:0037000.00729.8201>
+                                           ] ;
+            epcis:vocabularyList  [ a                            epcis:Vocabulary ;
+                                    epcis:type                   vtype:BusinessLocation ;
+                                    epcis:vocabularyElementList  <urn:epc:id:sgln:0037000.00729.8203> , <urn:epc:id:sgln:0037000.00729.8202> , <urn:epc:id:sgln:0037000.00729.8201> , <urn:epc:id:sgln:0037000.00729.0>
+                                  ] ]
+] .
+
+<urn:epc:id:sgln:0037000.00729.8202>
+        a               epcis:VocabularyElement ;
+        epcis:children  <urn:epc:id:sgln:0037000.00729.8203> ;
+        cbvmda:site     "0037000007296" ;
+        cbvmda:sst      202 , "202" .
+
+<urn:epc:id:sgln:0037000.00729.0>
+        a                 epcis:VocabularyElement ;
+        epcis:children    <urn:epc:id:sgln:0037000.00729.8203> , <urn:epc:id:sgln:0037000.00729.8202> , <urn:epc:id:sgln:0037000.00729.8201> ;
+        <xmda:address>    [ a       <http://epcis.example.com/ns/Address> ;
+                            <http://epcis.example.com/ns/city>
+                                    "Fancy" ;
+                            <http://epcis.example.com/ns/state>
+                                    "DC" ;
+                            <http://epcis.example.com/ns/street>
+                                    "100 Nowhere Street" ;
+                            <http://epcis.example.com/ns/zip>
+                                    "99999"
+                          ] ;
+        <xmda:latitude>   "+18:0000" ;
+        <xmda:longitude>  "-70.0000" .
+
+<urn:epc:id:sgln:0037000.00729.8203>
+        a           epcis:VocabularyElement ;
+        cbvmda:ssa  "402" ;
+        cbvmda:sst  204 , "202" .

--- a/Turtle/Example_9.8.1-MasterData.ttl
+++ b/Turtle/Example_9.8.1-MasterData.ttl
@@ -1,9 +1,11 @@
 @prefix epcis: <https://ns.gs1.org/epcis/> .
 @prefix gs1:   <https://gs1.org/voc/> .
 @prefix example2: <http://epcis.example.com/ns/> .
-@prefix owl:   <http://www.w3.org/2002/07/owl#> .
 @prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix vtype: <urn:epcglobal:epcis:vtype:> .
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix md:    <https://ns.gs1.org/epcismd/> .
+@prefix example-mda: <http://epcis.example.com/mda/> .
 @prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix example1: <http://ns.example.com/epcis/> .
@@ -21,6 +23,20 @@
         cbvmda:site     "0037000007296" ;
         cbvmda:sst      202 , "202" .
 
+[ a                epcis:EPCISMasterDataDocument ;
+  dcterms:created  "2005-07-11T11:30:47.0Z"^^xsd:dateTime ;
+  dcterms:format   "application/ld+json" ;
+  owl:versionInfo  "2" ;
+  epcis:epcisBody  [ epcis:vocabularyList  [ a                            epcis:Vocabulary ;
+                                             epcis:type                   vtype:ReadPoint ;
+                                             epcis:vocabularyElementList  <urn:epc:id:sgln:0037000.00729.8203> , <urn:epc:id:sgln:0037000.00729.8202> , <urn:epc:id:sgln:0037000.00729.8201>
+                                           ] ;
+            epcis:vocabularyList  [ a                            epcis:Vocabulary ;
+                                    epcis:type                   vtype:BusinessLocation ;
+                                    epcis:vocabularyElementList  <urn:epc:id:sgln:0037000.00729.8203> , <urn:epc:id:sgln:0037000.00729.8202> , <urn:epc:id:sgln:0037000.00729.8201> , <urn:epc:id:sgln:0037000.00729.0>
+                                  ] ]
+] .
+
 <urn:epc:id:sgln:0037000.00729.0>
         a                 epcis:VocabularyElement ;
         epcis:children    <urn:epc:id:sgln:0037000.00729.8203> , <urn:epc:id:sgln:0037000.00729.8202> , <urn:epc:id:sgln:0037000.00729.8201> ;
@@ -32,20 +48,6 @@
                           ] ;
         <xmda:latitude>   "+18:0000" ;
         <xmda:longitude>  "-70.0000" .
-
-[ a                epcis:EPCISMasterDataDocument ;
-  dcterms:created  "2005-07-11T11:30:47.0Z"^^xsd:dateTime ;
-  dcterms:format   "application/ld+json" ;
-  owl:versionInfo  "2.0" ;
-  epcis:epcisBody  [ epcis:vocabularyList  [ a                            epcis:Vocabulary ;
-                                             epcis:type                   vtype:ReadPoint ;
-                                             epcis:vocabularyElementList  <urn:epc:id:sgln:0037000.00729.8203> , <urn:epc:id:sgln:0037000.00729.8202> , <urn:epc:id:sgln:0037000.00729.8201>
-                                           ] ;
-            epcis:vocabularyList  [ a                            epcis:Vocabulary ;
-                                    epcis:type                   vtype:BusinessLocation ;
-                                    epcis:vocabularyElementList  <urn:epc:id:sgln:0037000.00729.8203> , <urn:epc:id:sgln:0037000.00729.8202> , <urn:epc:id:sgln:0037000.00729.8201> , <urn:epc:id:sgln:0037000.00729.0>
-                                  ] ]
-] .
 
 <urn:epc:id:sgln:0037000.00729.8203>
         a           epcis:VocabularyElement ;

--- a/Turtle/Example_9.8.1-improved.ttl
+++ b/Turtle/Example_9.8.1-improved.ttl
@@ -1,0 +1,48 @@
+@prefix epcis: <https://ns.gs1.org/epcis/> .
+@prefix gs1:   <https://gs1.org/voc/> .
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix vtype: <urn:epcglobal:epcis:vtype:> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix example: <http://ns.example.com/epcis/> .
+@prefix cbvmda: <urn:epcglobal:cbv:mda:> .
+
+<urn:epc:id:sgln:0037000.00729.8201>
+        a            vtype:ReadPoint , vtype:BusinessLocation ;
+        cbvmda:site  "0037000007296" ;
+        cbvmda:sst   "201" .
+
+<urn:epc:id:sgln:0037000.00729.8202>
+        a            vtype:ReadPoint , vtype:BusinessLocation ;
+        <https://ns.gs1.org/epcismd/children>
+                <urn:epc:id:sgln:0037000.00729.8203> ;
+        cbvmda:site  "0037000007296" ;
+        cbvmda:sst   "202" .
+
+<urn:epc:id:sgln:0037000.00729.0>
+        a       vtype:BusinessLocation ;
+        <http://epcis.example.com/mda/address>
+                [ a       <http://epcis.example.com/mda/Address> ;
+                  <http://epcis.example.com/mda/City>
+                          "Fancy" ;
+                  <http://epcis.example.com/mda/State>
+                          "DC" ;
+                  <http://epcis.example.com/mda/Street>
+                          "100 Nowhere Street" ;
+                  <http://epcis.example.com/mda/Zip>
+                          "99999"
+                ] ;
+        <http://epcis.example.com/mda/latitude>
+                "+18.000"^^xsd:float ;
+        <http://epcis.example.com/mda/longitude>
+                "-70.000"^^xsd:float ;
+        <https://ns.gs1.org/epcismd/children>
+                <urn:epc:id:sgln:0037000.00729.8203> , <urn:epc:id:sgln:0037000.00729.8202> , <urn:epc:id:sgln:0037000.00729.8201> .
+
+<urn:epc:id:sgln:0037000.00729.8203>
+        a            vtype:ReadPoint , vtype:BusinessLocation ;
+        cbvmda:site  "0037000007296" ;
+        cbvmda:ssa   "402" ;
+        cbvmda:sst   "203" , "202" .

--- a/Turtle/Example_9.8.1-improved.ttl
+++ b/Turtle/Example_9.8.1-improved.ttl
@@ -1,9 +1,11 @@
 @prefix epcis: <https://ns.gs1.org/epcis/> .
 @prefix gs1:   <https://gs1.org/voc/> .
 @prefix example2: <http://epcis.example.com/ns/> .
-@prefix owl:   <http://www.w3.org/2002/07/owl#> .
 @prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix vtype: <urn:epcglobal:epcis:vtype:> .
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix md:    <https://ns.gs1.org/epcismd/> .
+@prefix example-mda: <http://epcis.example.com/mda/> .
 @prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix example1: <http://ns.example.com/epcis/> .
@@ -17,30 +19,21 @@
 
 <urn:epc:id:sgln:0037000.00729.8202>
         a            vtype:ReadPoint , vtype:BusinessLocation ;
-        <https://ns.gs1.org/epcismd/children>
-                <urn:epc:id:sgln:0037000.00729.8203> ;
+        md:children  <urn:epc:id:sgln:0037000.00729.8203> ;
         cbvmda:site  "0037000007296" ;
         cbvmda:sst   "202" .
 
 <urn:epc:id:sgln:0037000.00729.0>
-        a       vtype:BusinessLocation ;
-        <http://epcis.example.com/mda/address>
-                [ a       <http://epcis.example.com/mda/Address> ;
-                  <http://epcis.example.com/mda/City>
-                          "Fancy" ;
-                  <http://epcis.example.com/mda/State>
-                          "DC" ;
-                  <http://epcis.example.com/mda/Street>
-                          "100 Nowhere Street" ;
-                  <http://epcis.example.com/mda/Zip>
-                          "99999"
-                ] ;
-        <http://epcis.example.com/mda/latitude>
-                "+18.000"^^xsd:float ;
-        <http://epcis.example.com/mda/longitude>
-                "-70.000"^^xsd:float ;
-        <https://ns.gs1.org/epcismd/children>
-                <urn:epc:id:sgln:0037000.00729.8203> , <urn:epc:id:sgln:0037000.00729.8202> , <urn:epc:id:sgln:0037000.00729.8201> .
+        a                      vtype:BusinessLocation ;
+        example-mda:address    [ a                   example-mda:Address ;
+                                 example-mda:City    "Fancy" ;
+                                 example-mda:State   "DC" ;
+                                 example-mda:Street  "100 Nowhere Street" ;
+                                 example-mda:Zip     "99999"
+                               ] ;
+        example-mda:latitude   "+18.000"^^xsd:float ;
+        example-mda:longitude  "-70.000"^^xsd:float ;
+        md:children            <urn:epc:id:sgln:0037000.00729.8203> , <urn:epc:id:sgln:0037000.00729.8202> , <urn:epc:id:sgln:0037000.00729.8201> .
 
 <urn:epc:id:sgln:0037000.00729.8203>
         a            vtype:ReadPoint , vtype:BusinessLocation ;

--- a/Turtle/Example_9.8.1-improved.ttl
+++ b/Turtle/Example_9.8.1-improved.ttl
@@ -1,12 +1,13 @@
 @prefix epcis: <https://ns.gs1.org/epcis/> .
 @prefix gs1:   <https://gs1.org/voc/> .
+@prefix example2: <http://epcis.example.com/ns/> .
 @prefix owl:   <http://www.w3.org/2002/07/owl#> .
 @prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix vtype: <urn:epcglobal:epcis:vtype:> .
 @prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix example1: <http://ns.example.com/epcis/> .
 @prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix example: <http://ns.example.com/epcis/> .
 @prefix cbvmda: <urn:epcglobal:cbv:mda:> .
 
 <urn:epc:id:sgln:0037000.00729.8201>

--- a/Turtle/Makefile
+++ b/Turtle/Makefile
@@ -1,0 +1,12 @@
+JSONLD = $(wildcard ../JSON/*.jsonld) $(wildcard ../JSON/*/*.jsonld)
+TTL    = $(JSONLD:../JSON/%.jsonld=%.ttl)
+
+all: $(TTL)
+
+# https://stackoverflow.com/questions/66764608/why-make-implicit-rule-doesnt-work-across-folders
+define jsonld2ttl
+$(1).ttl: ../JSON/$(1).jsonld
+	jsonld format -q $$^ | cat prefixes.ttl - | riot -syntax ttl -formatted ttl > $$@
+endef
+
+$(foreach X,$(patsubst ../JSON/%.jsonld,%,$(JSONLD)),$(eval $(call jsonld2ttl,$(X))))

--- a/Turtle/PersistentDisposition-example.ttl
+++ b/Turtle/PersistentDisposition-example.ttl
@@ -1,0 +1,75 @@
+@prefix epcis: <https://ns.gs1.org/epcis/> .
+@prefix gs1:   <https://gs1.org/voc/> .
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix vtype: <urn:epcglobal:epcis:vtype:> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix example: <http://ns.example.com/epcis/> .
+@prefix cbvmda: <urn:epcglobal:cbv:mda:> .
+
+<ni:///sha-256;56ba4f355c57456b41c3fb60b22d8342e759de503e3e618940ca3b6ad1bf9b00?ver=CBV2.0>
+        a                            epcis:AggregationEvent ;
+        epcis:action                 "OBSERVE" ;
+        epcis:bizLocation            <urn:epc:id:sgln:9529999.99999.0> ;
+        epcis:bizStep                <urn:epcglobal:cbv:bizstep:receiving> ;
+        epcis:bizTransactionList     [ epcis:bizTransaction  <urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6> ;
+                                       epcis:type            <urn:epcglobal:cbv:btt:desadv>
+                                     ] ;
+        epcis:bizTransactionList     [ epcis:bizTransaction  <urn:epcglobal:cbv:bt:9529999999991:XYZ567> ;
+                                       epcis:type            <urn:epcglobal:cbv:btt:po>
+                                     ] ;
+        epcis:bizTransactionList     [ epcis:bizTransaction  <urn:epcglobal:cbv:bt:9520011111116:A123> ;
+                                       epcis:type            <urn:epcglobal:cbv:btt:inv>
+                                     ] ;
+        epcis:childEPCs              <urn:epc:id:sgtin:9520001.012346.10000001010> , <urn:epc:id:sgtin:9520001.012346.10000001009> , <urn:epc:id:sgtin:9520001.012346.10000001008> , <urn:epc:id:sgtin:9520001.012346.10000001003> , <urn:epc:id:sgtin:9520001.012346.10000001002> , <urn:epc:id:sgtin:9520001.012346.10000001007> , <urn:epc:id:sgtin:9520001.012346.10000001006> , <urn:epc:id:sgtin:9520001.012346.10000001001> , <urn:epc:id:sgtin:9520001.012346.10000001005> , <urn:epc:id:sgtin:9520001.012346.10000001004> ;
+        epcis:destinationList        [ epcis:destination  <urn:epc:id:pgln:9520999.99999> ;
+                                       epcis:type         <urn:epcglobal:cbv:sdt:owning_party>
+                                     ] ;
+        epcis:disposition            <urn:epcglobal:cbv:disp:in_progress> ;
+        epcis:eventTime              "2020-06-07T17:10:16Z"^^xsd:dateTime ;
+        epcis:eventTimeZoneOffset    "+02:00" ;
+        epcis:parentID               <urn:epc:id:sgtin:952001.1012345.22222223333> ;
+        epcis:persistentDisposition  [ epcis:set  <urn:epcglobal:cbv:disp:completeness_inferred> ] ;
+        epcis:readPoint              <urn:epc:id:sgln:9529999.99999.0> ;
+        epcis:sourceList             [ epcis:source  <urn:epc:id:pgln:9520001.11111> ;
+                                       epcis:type    <urn:epcglobal:cbv:sdt:owning_party>
+                                     ] .
+
+[ a                epcis:EPCISDocument ;
+  dcterms:created  "2020-06-28T13:41:00.000Z"^^xsd:dateTime ;
+  dcterms:format   "application/ld+json" ;
+  owl:versionInfo  "2.0" ;
+  epcis:epcisBody  [ epcis:eventList  <ni:///sha-256;dae7b481207bb87f1d981c5f169b8138368ae152a41b002eaf36eca1f67d56f5?ver=CBV2.0> , <ni:///sha-256;56ba4f355c57456b41c3fb60b22d8342e759de503e3e618940ca3b6ad1bf9b00?ver=CBV2.0> ]
+] .
+
+<ni:///sha-256;dae7b481207bb87f1d981c5f169b8138368ae152a41b002eaf36eca1f67d56f5?ver=CBV2.0>
+        a                            epcis:AggregationEvent ;
+        epcis:action                 "DELETE" ;
+        epcis:bizLocation            <urn:epc:id:sgln:9529999.99999.0> ;
+        epcis:bizStep                <urn:epcglobal:cbv:bizstep:unpacking> ;
+        epcis:bizTransactionList     [ epcis:bizTransaction  <urn:epcglobal:cbv:bt:9529999999991:XYZ567> ;
+                                       epcis:type            <urn:epcglobal:cbv:btt:po>
+                                     ] ;
+        epcis:bizTransactionList     [ epcis:bizTransaction  <urn:epcglobal:cbv:bt:9520011111116:A123> ;
+                                       epcis:type            <urn:epcglobal:cbv:btt:inv>
+                                     ] ;
+        epcis:bizTransactionList     [ epcis:bizTransaction  <urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6> ;
+                                       epcis:type            <urn:epcglobal:cbv:btt:desadv>
+                                     ] ;
+        epcis:childEPCs              <urn:epc:id:sgtin:9520001.012346.10000001003> , <urn:epc:id:sgtin:9520001.012346.10000001010> , <urn:epc:id:sgtin:9520001.012346.10000001006> , <urn:epc:id:sgtin:9520001.012346.10000001008> , <urn:epc:id:sgtin:9520001.012346.10000001005> , <urn:epc:id:sgtin:9520001.012346.10000001007> , <urn:epc:id:sgtin:9520001.012346.10000001009> , <urn:epc:id:sgtin:9520001.012346.10000001002> , <urn:epc:id:sgtin:9520001.012346.10000001001> , <urn:epc:id:sgtin:9520001.012346.10000001004> ;
+        epcis:destinationList        [ epcis:destination  <urn:epc:id:pgln:9520999.99999> ;
+                                       epcis:type         <urn:epcglobal:cbv:sdt:owning_party>
+                                     ] ;
+        epcis:disposition            <urn:epcglobal:cbv:disp:in_progress> ;
+        epcis:eventTime              "2020-06-08T18:11:16Z"^^xsd:dateTime ;
+        epcis:eventTimeZoneOffset    "+02:00" ;
+        epcis:parentID               <urn:epc:id:sgtin:952001.1012345.22222223333> ;
+        epcis:persistentDisposition  [ epcis:set    <urn:epcglobal:cbv:disp:completeness_verified> ;
+                                       epcis:unset  <urn:epcglobal:cbv:disp:completeness_inferred>
+                                     ] ;
+        epcis:readPoint              <urn:epc:id:sgln:9529999.99999.0> ;
+        epcis:sourceList             [ epcis:source  <urn:epc:id:pgln:9520001.11111> ;
+                                       epcis:type    <urn:epcglobal:cbv:sdt:owning_party>
+                                     ] .

--- a/Turtle/README.md
+++ b/Turtle/README.md
@@ -1,0 +1,115 @@
+# EPCIS RDF Turtle Examples
+
+We convert all JSON and JSON-LD examples to RDF Turtle automatically for two purposes:
+
+- Turtle is easier to read than JSON-LD
+- To validate the faithfulness of the JSON-LD representation and check the details of the corresponding RDF
+
+## jsonld-cli
+
+We use the `jsonld-cli` command-line tool, which uses the JSONLD Playground code and packages it as a `node.js` module (NPM).
+- Source: https://github.com/digitalbazaar/jsonld-cli
+- Package: https://www.npmjs.com/package/jsonld-cli
+- Latest version: 0.3.0 (dated 2018)
+
+### Installation
+
+On Windows: install prerequisites (Python 2.7 and Microsoft CPP). Do this from `cmd`, not `cygwin bash`:
+```
+npm install --global --production windows-build-tools
+setx VCTargetsPath "%programfiles(x86)%\MSBuild\Microsoft.Cpp\v4.0\V140"
+```
+
+Then install like this:
+```
+npm install -g jsonld-cli
+```
+
+You may get some warnings, they seem to be harmless. Eg:
+```
+npm WARN deprecated request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142
+npm WARN deprecated har-validator@5.1.5: this library is no longer supported
+npm WARN deprecated request-promise-native@1.0.9: request-promise-native has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142
+C:\Users\...\AppData\Roaming\npm\jsonld -> C:\Users\...\AppData\Roaming\npm\node_modules\jsonld-cli\bin\jsonld
++ jsonld-cli@0.3.0
+added 3 packages from 11 contributors, removed 2 packages and updated 41 packages in 18.755s
+```
+
+### Help
+
+The builtin help `jsonld -h` is quite poor, so we dug out the options from the source https://github.com/digitalbazaar/jsonld-cli/blob/master/bin/jsonld:
+```
+COMMON OPTIONS
+  -i, --indent <spaces>                   spaces to indent [2]
+  -N, --no-newline                        do not output the trailing newline [newline]
+  -k, --insecure                          allow insecure SSL connections [false]
+  -t, --type <type>                       input data type [auto]
+  -b, --base <base>                       base IRI []
+format [options] [filename|URL|-]     format and convert JSON-LD
+  -f, --format <format>                   output format [json]
+  -q, --nquads                            output application/nquads [false]
+  -j, --json                              output application/json [true]
+compact [options] [filename|URL]      compact JSON-LD
+  -c, --context <filename|URL>            context filename or URL
+  -S, --no-strict                         disable strict mode
+  -A, --no-compact-arrays                 disable compacting arrays to single values
+  -g, --graph                             always output top-level graph [false]
+expand [options] [filename|URL|-]     expand JSON-LD
+      --keep-free-floating-nodes          keep free-floating nodes
+flatten [options] [filename|URL|-]    flatten JSON-LD
+  -c, --context <filename|URL>            context filename or URL for compaction [none]
+frame [options] [filename|URL|-]      frame JSON-LD
+  -f, --frame <filename|URL>              frame to use
+      --embed <embed>                     default @embed flag [true]
+      --explicit <explicit>               default @explicit flag [false]
+      --omit-default <omit-default>       default @omitDefault flag [false]
+normalize [options] [filename|URL|-]  normalize JSON-LD
+  -f, --format <format>                   format to output ('application/nquads' for N-Quads)
+  -q, --nquads                            use 'application/nquads' format
+```
+The builtin help gives the following useful advice:
+- The input parameter for all commands can be a filename, a URL beginning with "http://" or "https://", or "-" for stdin (the default).
+- Input type can be specified as a standard content type or a simple string for common types. See the "request" extension code for available types. XML and HTML variations will be converted with an RDFa processor if available. If the input type is not specified it will be auto-detected based on file extension, URL content type, or by guessing with various parsers. Guessing may not always produce correct results.
+- Output type can be specified for the "format" command and a N-Quads shortcut for the "normalize" command. For other commands you can pipe JSON-LD output to the "format" command.
+
+## jena riot
+
+`jsonld-cli` can output only `nquads`, eg:
+
+```sh
+jsonld format -f text/turtle ../JSON/Example_9.6.1-ObjectEvent.jsonld > Example_9.6.1-ObjectEvent.ttl
+Error: ERROR: Unknown format: text/turtle
+```
+
+So we also use `riot` from Apache Jena:
+- Download: https://jena.apache.org/download/
+
+We make a file `prefixes.ttl` that defines the same prefixes as the EPCIS context, and postprocess with `riot` to make nicely formtted Turtle
+(we use the fact that the `nquads` format output by `jsonld`, when no named graphs are used, is compatible with the `ttl` format):
+
+```sh
+jsonld format -q ../JSON/Example_9.6.1-ObjectEvent.jsonld | \
+  cat prefixes.ttl - | riot -syntax ttl -formatted ttl > Example_9.6.1-ObjectEvent.ttl
+```
+
+## Context Issues
+
+All JSON/JSON-LD examples declare their own context, usually something like this (first is the EPCIS context, then some custom extensions):
+
+```json
+  "@context": ["https://gs1.github.io/EPCIS/epcis-context.jsonld",
+               {"example": "http://ns.example.com/epcis/"},
+               {"gs1": "https://gs1.org/voc/"}],
+```
+
+The EPCIS context is served from a Github page and corresponds to the local version [../epcis-context.jsonld](../epcis-context.jsonld) in this repository
+(it may show as a smaller file because it uses NL line endings, whereas the local version uses CR+NL line endings on Windows).
+This means that:
+- Whenever changes are made to [../epcis-context.jsonld](../epcis-context.jsonld), it will take time until it's deployed at Github pages. 
+  Furthermore, Github pages aggressively use caching, so one may still get the old context.
+- The version in development [../epcis-context-protected.jsonld](../epcis-context-protected.jsonld) cannot be tested so easily.
+
+For example, error #201 still occurs for one of the examples because 
+the change `xsd:decimal -> xsd:float` is still not deployed in the context.
+
+TODO: see if option `-c` can override the context specified in-file.

--- a/Turtle/WithDigitalLinkID/Example_9.6.1-ObjectEventWithDigitalLink.ttl
+++ b/Turtle/WithDigitalLinkID/Example_9.6.1-ObjectEventWithDigitalLink.ttl
@@ -1,0 +1,48 @@
+@prefix epcis: <https://ns.gs1.org/epcis/> .
+@prefix gs1:   <https://gs1.org/voc/> .
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix vtype: <urn:epcglobal:epcis:vtype:> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix example: <http://ns.example.com/epcis/> .
+@prefix cbvmda: <urn:epcglobal:cbv:mda:> .
+
+[ a                epcis:EPCISDocument ;
+  dcterms:created  "2005-07-11T11:30:47.0Z"^^xsd:dateTime ;
+  dcterms:format   "application/ld+json" ;
+  owl:versionInfo  "2.0" ;
+  epcis:epcisBody  [ epcis:eventList  <ni:///sha-256;9fa42e8bf64e1cfe152d582a248646ce0ad2b0c6826c7e8ed95442a7a1545f33?ver=CBV2.0> , <ni:///sha-256;4217c6a122625b7b9d8ae4f9b89890df35ffa0c501471a096cbfdeebd7207e45?ver=CBV2.0> ]
+] .
+
+<ni:///sha-256;4217c6a122625b7b9d8ae4f9b89890df35ffa0c501471a096cbfdeebd7207e45?ver=CBV2.0>
+        a                          epcis:ObjectEvent ;
+        example:myField            "Example of a vendor/user extension" ;
+        epcis:action               "OBSERVE" ;
+        epcis:bizLocation          <urn:epc:id:sgln:0012345.11111.0> ;
+        epcis:bizStep              <urn:epcglobal:cbv:bizstep:receiving> ;
+        epcis:bizTransactionList   [ epcis:bizTransaction  <http://transaction.acme.com/po/12345678> ;
+                                     epcis:type            <urn:epcglobal:cbv:btt:po>
+                                   ] ;
+        epcis:bizTransactionList   [ epcis:bizTransaction  <urn:epcglobal:cbv:bt:0614141073467:1152> ;
+                                     epcis:type            <urn:epcglobal:cbv:btt:desadv>
+                                   ] ;
+        epcis:disposition          <urn:epcglobal:cbv:disp:in_progress> ;
+        epcis:epcList              <https://id.gs1.org/01/70614141123451/21/2018> ;
+        epcis:eventTime            "2005-04-04T20:33:31.116-06:00"^^xsd:dateTime ;
+        epcis:eventTimeZoneOffset  "-06:00" ;
+        epcis:readPoint            <urn:epc:id:sgln:0012345.11111.400> .
+
+<ni:///sha-256;9fa42e8bf64e1cfe152d582a248646ce0ad2b0c6826c7e8ed95442a7a1545f33?ver=CBV2.0>
+        a                          epcis:ObjectEvent ;
+        epcis:action               "OBSERVE" ;
+        epcis:bizStep              <urn:epcglobal:cbv:bizstep:shipping> ;
+        epcis:bizTransactionList   [ epcis:bizTransaction  <http://transaction.acme.com/po/12345678> ;
+                                     epcis:type            <urn:epcglobal:cbv:btt:po>
+                                   ] ;
+        epcis:disposition          <urn:epcglobal:cbv:disp:in_transit> ;
+        epcis:epcList              <https://id.gs1.org/01/70614141123451/21/2018> , <https://id.gs1.org/01/70614141123451/21/2017> ;
+        epcis:eventTime            "2005-04-03T20:33:31.116000-06:00"^^xsd:dateTime ;
+        epcis:eventTimeZoneOffset  "-06:00" ;
+        epcis:readPoint            <urn:epc:id:sgln:0614141.07346.1234> .

--- a/Turtle/WithDigitalLinkID/Example_9.6.2-ObjectEventWithDigitalLink.ttl
+++ b/Turtle/WithDigitalLinkID/Example_9.6.2-ObjectEventWithDigitalLink.ttl
@@ -1,0 +1,44 @@
+@prefix epcis: <https://ns.gs1.org/epcis/> .
+@prefix gs1:   <https://gs1.org/voc/> .
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix vtype: <urn:epcglobal:epcis:vtype:> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix example: <http://ns.example.com/epcis/> .
+@prefix cbvmda: <urn:epcglobal:cbv:mda:> .
+
+[ a                epcis:EPCISDocument ;
+  dcterms:created  "2005-07-11T11:30:47.0Z"^^xsd:dateTime ;
+  dcterms:format   "application/ld+json" ;
+  owl:versionInfo  "2.0" ;
+  epcis:epcisBody  [ epcis:eventList  <ni:///sha-256;115b14983df54a9bcc3dd6a00dc4ebcab000bd52fda0abdd8996907e01dccc23?ver=CBV2.0> ]
+] .
+
+<ni:///sha-256;115b14983df54a9bcc3dd6a00dc4ebcab000bd52fda0abdd8996907e01dccc23?ver=CBV2.0>
+        a                          epcis:ObjectEvent ;
+        example:myField            "Example of a vendor/user extension" ;
+        epcis:action               "OBSERVE" ;
+        epcis:bizLocation          <urn:epc:id:sgln:0614141.00888.0> ;
+        epcis:bizStep              <urn:epcglobal:cbv:bizstep:receiving> ;
+        epcis:destinationList      [ epcis:destination  <urn:epc:id:sgln:0614141.00777.0> ;
+                                     epcis:type         <urn:epcglobal:cbv:sdt:location>
+                                   ] ;
+        epcis:destinationList      [ epcis:destination  <urn:epc:id:sgln:0614141.00001.0> ;
+                                     epcis:type         <urn:epcglobal:cbv:sdt:owning_party>
+                                   ] ;
+        epcis:disposition          <urn:epcglobal:cbv:disp:in_progress> ;
+        epcis:eventTime            "2013-06-08T14:58:56.591Z"^^xsd:dateTime ;
+        epcis:eventTimeZoneOffset  "+02:00" ;
+        epcis:quantityList         [ epcis:epcClass  <https://id.gs1.org/01/70614141123451/10/998877> ;
+                                     epcis:quantity  "200"^^xsd:decimal ;
+                                     epcis:uom       "KGM"
+                                   ] ;
+        epcis:readPoint            <urn:epc:id:sgln:0614141.00777.0> ;
+        epcis:sourceList           [ epcis:source  <urn:epc:id:sgln:4012345.00001.0> ;
+                                     epcis:type    <urn:epcglobal:cbv:sdt:possessing_party>
+                                   ] ;
+        epcis:sourceList           [ epcis:source  <urn:epc:id:sgln:4012345.00225.0> ;
+                                     epcis:type    <urn:epcglobal:cbv:sdt:location>
+                                   ] .

--- a/Turtle/WithDigitalLinkID/Example_9.6.3-AggregationEventWithDigitalLink.ttl
+++ b/Turtle/WithDigitalLinkID/Example_9.6.3-AggregationEventWithDigitalLink.ttl
@@ -1,0 +1,37 @@
+@prefix epcis: <https://ns.gs1.org/epcis/> .
+@prefix gs1:   <https://gs1.org/voc/> .
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix vtype: <urn:epcglobal:epcis:vtype:> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix example: <http://ns.example.com/epcis/> .
+@prefix cbvmda: <urn:epcglobal:cbv:mda:> .
+
+[ a                epcis:EPCISDocument ;
+  dcterms:created  "2005-07-11T11:30:47.0Z"^^xsd:dateTime ;
+  dcterms:format   "application/ld+json" ;
+  owl:versionInfo  "2.0" ;
+  epcis:epcisBody  [ epcis:eventList  <ni:///sha-256;20a2b5b9681b7a70413c42bfe72db61386411252a803b6bc212f5f46f26649d7?ver=CBV2.0> ]
+] .
+
+<ni:///sha-256;20a2b5b9681b7a70413c42bfe72db61386411252a803b6bc212f5f46f26649d7?ver=CBV2.0>
+        a                          epcis:AggregationEvent ;
+        example:myField            "Example of a vendor/user extension" ;
+        epcis:action               "OBSERVE" ;
+        epcis:bizLocation          <urn:epc:id:sgln:0614141.00888.0> ;
+        epcis:bizStep              <urn:epcglobal:cbv:bizstep:receiving> ;
+        epcis:childEPCs            <https://id.gs1.org/01/70614141123451/21/2018> , <https://id.gs1.org/01/70614141123451/21/2017> ;
+        epcis:childQuantityList    [ epcis:epcClass  <https://id.gs1.org/01/04012345123456/10/998877> ;
+                                     epcis:quantity  "2.005E2"^^xsd:decimal ;
+                                     epcis:uom       "KGM"
+                                   ] ;
+        epcis:childQuantityList    [ epcis:epcClass  <https://id.gs1.org/01/04012345987652> ;
+                                     epcis:quantity  "10"^^xsd:decimal
+                                   ] ;
+        epcis:disposition          <urn:epcglobal:cbv:disp:in_progress> ;
+        epcis:eventTime            "2013-06-08T14:58:56.591Z"^^xsd:dateTime ;
+        epcis:eventTimeZoneOffset  "+02:00" ;
+        epcis:parentID             <urn:epc:id:sscc:0614141.1234567890> ;
+        epcis:readPoint            <urn:epc:id:sgln:0614141.00777.0> .

--- a/Turtle/WithDigitalLinkID/Example_9.6.4-TransformationEventWithDigitalLink.ttl
+++ b/Turtle/WithDigitalLinkID/Example_9.6.4-TransformationEventWithDigitalLink.ttl
@@ -1,0 +1,41 @@
+@prefix epcis: <https://ns.gs1.org/epcis/> .
+@prefix gs1:   <https://gs1.org/voc/> .
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix vtype: <urn:epcglobal:epcis:vtype:> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix example: <http://ns.example.com/epcis/> .
+@prefix cbvmda: <urn:epcglobal:cbv:mda:> .
+
+[ a                epcis:EPCISDocument ;
+  dcterms:created  "2013-06-04T14:59:02.099+02:00"^^xsd:dateTime ;
+  dcterms:format   "application/ld+json" ;
+  owl:versionInfo  "2.0" ;
+  epcis:epcisBody  [ epcis:eventList  <ni:///sha-256;4f143d1adf7b2950a34f5e82a240ce5280530b06a9f3c2b9cfe49f5ca5001815?ver=CBV2.0> ]
+] .
+
+<ni:///sha-256;4f143d1adf7b2950a34f5e82a240ce5280530b06a9f3c2b9cfe49f5ca5001815?ver=CBV2.0>
+        a                          epcis:TransformationEvent ;
+        example:myField            "Example of a vendor/user extension" ;
+        epcis:bizStep              <urn:epcglobal:cbv:bizstep:commissioning> ;
+        epcis:disposition          <urn:epcglobal:cbv:disp:in_progress> ;
+        epcis:eventTime            "2013-10-31T14:58:56.591Z"^^xsd:dateTime ;
+        epcis:eventTimeZoneOffset  "+02:00" ;
+        epcis:ilmd                 [ example:batch           "XYZ" ;
+                                     example:bestBeforeDate  "2014-12-10"
+                                   ] ;
+        epcis:inputEPCList         <urn:epc:id:sgtin:4012345.011122.25> , <urn:epc:id:sgtin:4000001.065432.99886655> ;
+        epcis:inputQuantityList    [ epcis:epcClass  <https://id.gs1.org/01/00614141777778/10/987> ;
+                                     epcis:quantity  "30"^^xsd:decimal
+                                   ] ;
+        epcis:inputQuantityList    [ epcis:epcClass  <urn:epc:class:lgtin:4012345.011111.4444> ;
+                                     epcis:quantity  "10"^^xsd:decimal ;
+                                     epcis:uom       "KGM"
+                                   ] ;
+        epcis:inputQuantityList    [ epcis:epcClass  <https://id.gs1.org/01/04012345666663> ;
+                                     epcis:quantity  "220"^^xsd:decimal
+                                   ] ;
+        epcis:outputEPCList        <urn:epc:id:sgtin:4012345.077889.28> , <urn:epc:id:sgtin:4012345.077889.25> , <urn:epc:id:sgtin:4012345.077889.27> , <urn:epc:id:sgtin:4012345.077889.26> ;
+        epcis:readPoint            <urn:epc:id:sgln:4012345.00001.0> .

--- a/Turtle/WithErrorDeclaration/ErrorDeclarationAndCorrectiveEvent.ttl
+++ b/Turtle/WithErrorDeclaration/ErrorDeclarationAndCorrectiveEvent.ttl
@@ -1,0 +1,56 @@
+@prefix epcis: <https://ns.gs1.org/epcis/> .
+@prefix gs1:   <https://gs1.org/voc/> .
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix vtype: <urn:epcglobal:epcis:vtype:> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix example: <http://ns.example.com/epcis/> .
+@prefix cbvmda: <urn:epcglobal:cbv:mda:> .
+
+[ a                epcis:EPCISDocument ;
+  dcterms:created  "2020-01-15T07:47:21.677+00:00"^^xsd:dateTime ;
+  dcterms:format   "application/ld+json" ;
+  owl:versionInfo  "1.2E0" ;
+  epcis:epcisBody  [ epcis:eventList  <urn:uuid:404d95fc-9457-4a51-bd6a-0bba133845a8> , <urn:uuid:374d95fc-9457-4a51-bd6a-0bba133845a8> ]
+] .
+
+<urn:uuid:374d95fc-9457-4a51-bd6a-0bba133845a8>
+        a                          epcis:TransformationEvent ;
+        epcis:bizStep              <urn:epcglobal:cbv:bizstep:commissioning> ;
+        epcis:errorDeclaration     [ example:vendorExtension   "Test1" ;
+                                     epcis:correctiveEventIDs  <urn:uuid:404d95fc-9457-4a51-bd6a-0bba133845a8> ;
+                                     epcis:declarationTime     "2020-01-15T00:00:00+01:00"^^xsd:dateTime ;
+                                     epcis:reason              <urn:epcglobal:cbv:er:incorrect_data>
+                                   ] ;
+        epcis:eventTime            "2020-01-14T00:00:00+01:00"^^xsd:dateTime ;
+        epcis:eventTimeZoneOffset  "+01:00" ;
+        epcis:inputEPCList         <urn:epc:id:sgtin:4012345.011111.987> ;
+        epcis:inputQuantityList    [ epcis:epcClass  <urn:epc:class:lgtin:4012345.022222.87545GHGH> ;
+                                     epcis:quantity  "500"^^xsd:decimal ;
+                                     epcis:uom       "KGM"
+                                   ] ;
+        epcis:outputEPCList        <urn:epc:id:sgtin:4012345.033333.AGHFG> ;
+        epcis:outputQuantityList   [ epcis:epcClass  <urn:epc:idpat:sgtin:4012345.044444.*> ;
+                                     epcis:quantity  "452"^^xsd:decimal ;
+                                     epcis:uom       "KGM"
+                                   ] ;
+        epcis:readPoint            <urn:epc:id:sgln:0614141.07346.1234> .
+
+<urn:uuid:404d95fc-9457-4a51-bd6a-0bba133845a8>
+        a                          epcis:TransformationEvent ;
+        epcis:bizStep              <urn:epcglobal:cbv:bizstep:commissioning> ;
+        epcis:eventTime            "2021-01-28T00:00:00+01:00"^^xsd:dateTime ;
+        epcis:eventTimeZoneOffset  "+01:00" ;
+        epcis:inputEPCList         <urn:epc:id:sgtin:4012345.011111.987> ;
+        epcis:inputQuantityList    [ epcis:epcClass  <urn:epc:class:lgtin:4012345.022222.87545GHGH> ;
+                                     epcis:quantity  "500"^^xsd:decimal ;
+                                     epcis:uom       "KGM"
+                                   ] ;
+        epcis:outputEPCList        <urn:epc:id:sgtin:4012345.033333.AGHFG> ;
+        epcis:outputQuantityList   [ epcis:epcClass  <urn:epc:idpat:sgtin:4012345.044444.*> ;
+                                     epcis:quantity  "500"^^xsd:decimal ;
+                                     epcis:uom       "KGM"
+                                   ] ;
+        epcis:readPoint            <urn:epc:id:sgln:0614141.07346.1234> .

--- a/Turtle/WithSensorData/SensorDataExample1.ttl
+++ b/Turtle/WithSensorData/SensorDataExample1.ttl
@@ -1,0 +1,95 @@
+@prefix epcis: <https://ns.gs1.org/epcis/> .
+@prefix gs1:   <https://gs1.org/voc/> .
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix vtype: <urn:epcglobal:epcis:vtype:> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix example: <http://ns.example.com/epcis/> .
+@prefix cbvmda: <urn:epcglobal:cbv:mda:> .
+
+[ a                epcis:EPCISDocument ;
+  dcterms:created  "2005-07-11T11:30:47.0Z"^^xsd:dateTime ;
+  dcterms:format   "application/ld+json" ;
+  owl:versionInfo  "2.0" ;
+  epcis:epcisBody  [ epcis:eventList  <ni:///sha-256;74f1dc48ee22289bc40ddd9f1d0ecae0dd09a2f4c3dfa66fdbca16cb2d8a4e77?ver=CBV2.0> ]
+] .
+
+<ni:///sha-256;74f1dc48ee22289bc40ddd9f1d0ecae0dd09a2f4c3dfa66fdbca16cb2d8a4e77?ver=CBV2.0>
+        a                          epcis:ObjectEvent ;
+        epcis:action               "OBSERVE" ;
+        epcis:bizStep              <urn:epcglobal:cbv:bizstep:inspecting> ;
+        epcis:epcList              <urn:epc:id:sgtin:4012345.011111.9876> ;
+        epcis:eventTime            "2019-04-02T15:00:00.000+01:00"^^xsd:dateTime ;
+        epcis:eventTimeZoneOffset  "+01:00" ;
+        epcis:readPoint            <urn:epc:id:sgln:4012345.00005.0> ;
+        epcis:sensorElementList    [ a                     epcis:SensorElement ;
+                                     epcis:sensorMetadata  [ epcis:deviceID        <urn:epc:id:giai:4000001.111> ;
+                                                             epcis:deviceMetadata  <https://id.gs1.org/giai/4000001111> ;
+                                                             epcis:rawData         <https://example.org/giai/401234599999> ;
+                                                             epcis:time            "2019-04-02T14:05:00.000+01:00"^^xsd:dateTime
+                                                           ] ;
+                                     epcis:sensorReport    [ epcis:type   gs1:MT-Illuminance ;
+                                                             epcis:uom    "LUX" ;
+                                                             epcis:value  "800"^^xsd:float
+                                                           ] ;
+                                     epcis:sensorReport    [ epcis:type   gs1:MT-Speed ;
+                                                             epcis:uom    "KMH" ;
+                                                             epcis:value  "160"^^xsd:float
+                                                           ] ;
+                                     epcis:sensorReport    [ epcis:type   gs1:MT-Humidity ;
+                                                             epcis:uom    "A93" ;
+                                                             epcis:value  "1.21E1"^^xsd:float
+                                                           ] ;
+                                     epcis:sensorReport    [ epcis:type   gs1:MT-Temperature ;
+                                                             epcis:uom    "CEL" ;
+                                                             epcis:value  "26"^^xsd:float
+                                                           ]
+                                   ] ;
+        epcis:sensorElementList    [ a                     epcis:SensorElement ;
+                                     epcis:sensorMetadata  [ epcis:deviceID        <urn:epc:id:giai:4000001.111> ;
+                                                             epcis:deviceMetadata  <https://id.gs1.org/giai/4000001111> ;
+                                                             epcis:rawData         <https://example.org/giai/401234599999> ;
+                                                             epcis:time            "2019-04-02T14:55:00.000+01:00"^^xsd:dateTime
+                                                           ] ;
+                                     epcis:sensorReport    [ epcis:type   gs1:MT-Illuminance ;
+                                                             epcis:uom    "LUX" ;
+                                                             epcis:value  "802"^^xsd:float
+                                                           ] ;
+                                     epcis:sensorReport    [ epcis:type   gs1:MT-Speed ;
+                                                             epcis:uom    "KMH" ;
+                                                             epcis:value  "162"^^xsd:float
+                                                           ] ;
+                                     epcis:sensorReport    [ epcis:type   gs1:MT-Humidity ;
+                                                             epcis:uom    "A93" ;
+                                                             epcis:value  "1.22E1"^^xsd:float
+                                                           ] ;
+                                     epcis:sensorReport    [ epcis:type   gs1:MT-Temperature ;
+                                                             epcis:uom    "CEL" ;
+                                                             epcis:value  "2.62E1"^^xsd:float
+                                                           ]
+                                   ] ;
+        epcis:sensorElementList    [ a                     epcis:SensorElement ;
+                                     epcis:sensorMetadata  [ epcis:deviceID        <urn:epc:id:giai:4000001.111> ;
+                                                             epcis:deviceMetadata  <https://id.gs1.org/giai/4000001111> ;
+                                                             epcis:rawData         <https://example.org/giai/401234599999> ;
+                                                             epcis:time            "2019-04-02T14:35:00.000+01:00"^^xsd:dateTime
+                                                           ] ;
+                                     epcis:sensorReport    [ epcis:type   gs1:MT-Illuminance ;
+                                                             epcis:uom    "LUX" ;
+                                                             epcis:value  "801"^^xsd:float
+                                                           ] ;
+                                     epcis:sensorReport    [ epcis:type   gs1:MT-Speed ;
+                                                             epcis:uom    "KMH" ;
+                                                             epcis:value  "161"^^xsd:float
+                                                           ] ;
+                                     epcis:sensorReport    [ epcis:type   gs1:MT-Humidity ;
+                                                             epcis:uom    "A93" ;
+                                                             epcis:value  "1.22E1"^^xsd:float
+                                                           ] ;
+                                     epcis:sensorReport    [ epcis:type   gs1:MT-Temperature ;
+                                                             epcis:uom    "CEL" ;
+                                                             epcis:value  "2.61E1"^^xsd:float
+                                                           ]
+                                   ] .

--- a/Turtle/WithSensorData/SensorDataExample11.ttl
+++ b/Turtle/WithSensorData/SensorDataExample11.ttl
@@ -1,0 +1,35 @@
+@prefix epcis: <https://ns.gs1.org/epcis/> .
+@prefix gs1:   <https://gs1.org/voc/> .
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix vtype: <urn:epcglobal:epcis:vtype:> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix example: <http://ns.example.com/epcis/> .
+@prefix cbvmda: <urn:epcglobal:cbv:mda:> .
+
+[ a                epcis:EPCISDocument ;
+  dcterms:created  "2020-07-03T00:05:00-06:00"^^xsd:dateTime ;
+  dcterms:format   "application/ld+json" ;
+  owl:versionInfo  "2.0" ;
+  epcis:epcisBody  [ epcis:eventList  <ni:///sha-256;8702ac80df8ac48d19cc0c8d19399249fc7037f8b752acb97baf7148960d2a17?ver=CBV2.0> ]
+] .
+
+<ni:///sha-256;8702ac80df8ac48d19cc0c8d19399249fc7037f8b752acb97baf7148960d2a17?ver=CBV2.0>
+        a                          epcis:TransactionEvent ;
+        epcis:action               "ADD" ;
+        epcis:bizStep              <urn:epcglobal:cbv:bizstep:inspecting> ;
+        epcis:bizTransactionList   [ epcis:bizTransaction  <urn:epcglobal:cbv:bt:4012345123456:RE100099> ;
+                                     epcis:type            <urn:epcglobal:cbv:btt:po>
+                                   ] ;
+        epcis:disposition          <urn:epcglobal:cbv:disp:needs_replacement> ;
+        epcis:epcList              <urn:epc:id:sgtin:0614141.107340.2> , <urn:epc:id:sgtin:0614141.107340.1> ;
+        epcis:eventTime            "2020-07-03T00:05:00-06:00"^^xsd:dateTime ;
+        epcis:eventTimeZoneOffset  "-06:00" ;
+        epcis:readPoint            <urn:epc:id:sgln:4012345.00000.5> ;
+        epcis:sensorElementList    [ epcis:sensorReport
+                          [ epcis:type   gs1:MT-EffectiveDoseRate ;
+                            epcis:uom    "P71" ;
+                            epcis:value  "5.0E-3"^^xsd:float
+                          ] ] .

--- a/Turtle/WithSensorData/SensorDataExample1b.ttl
+++ b/Turtle/WithSensorData/SensorDataExample1b.ttl
@@ -1,0 +1,91 @@
+@prefix epcis: <https://ns.gs1.org/epcis/> .
+@prefix gs1:   <https://gs1.org/voc/> .
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix vtype: <urn:epcglobal:epcis:vtype:> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix example: <http://ns.example.com/epcis/> .
+@prefix cbvmda: <urn:epcglobal:cbv:mda:> .
+
+<ni:///sha-256;e84840e98e15b9c86168ce85ca277af4241dddd3b658f9650a00096c2a09c2f3?ver=CBV2.0>
+        a                          epcis:ObjectEvent ;
+        epcis:action               "OBSERVE" ;
+        epcis:bizStep              <urn:epcglobal:cbv:bizstep:inspecting> ;
+        epcis:eventTime            "2019-04-02T15:00:00.000+01:00"^^xsd:dateTime ;
+        epcis:eventTimeZoneOffset  "+01:00" ;
+        epcis:readPoint            <urn:epc:id:sgln:4012345.00005.0> ;
+        epcis:sensorElementList    [ epcis:sensorMetadata  [ epcis:deviceID        <urn:epc:id:giai:4000001.111> ;
+                                                             epcis:deviceMetadata  <https://id.gs1.org/giai/4000001111> ;
+                                                             epcis:rawData         <https://example.org/giai/401234599999> ;
+                                                             epcis:time            "2019-04-02T14:35:00.000+01:00"^^xsd:dateTime
+                                                           ] ;
+                                     epcis:sensorReport    [ epcis:type   gs1:MT-Illuminance ;
+                                                             epcis:uom    "LUX" ;
+                                                             epcis:value  "801"^^xsd:float
+                                                           ] ;
+                                     epcis:sensorReport    [ epcis:type   gs1:MT-Speed ;
+                                                             epcis:uom    "KMH" ;
+                                                             epcis:value  "161"^^xsd:float
+                                                           ] ;
+                                     epcis:sensorReport    [ epcis:type   gs1:MT-Humidity ;
+                                                             epcis:uom    "A93" ;
+                                                             epcis:value  "1.22E1"^^xsd:float
+                                                           ] ;
+                                     epcis:sensorReport    [ epcis:type   gs1:MT-Temperature ;
+                                                             epcis:uom    "CEL" ;
+                                                             epcis:value  "2.61E1"^^xsd:float
+                                                           ]
+                                   ] ;
+        epcis:sensorElementList    [ epcis:sensorMetadata  [ epcis:deviceID        <urn:epc:id:giai:4000001.111> ;
+                                                             epcis:deviceMetadata  <https://id.gs1.org/giai/4000001111> ;
+                                                             epcis:rawData         <https://example.org/giai/401234599999> ;
+                                                             epcis:time            "2019-04-02T14:05:00.000+01:00"^^xsd:dateTime
+                                                           ] ;
+                                     epcis:sensorReport    [ epcis:type   gs1:MT-Illuminance ;
+                                                             epcis:uom    "LUX" ;
+                                                             epcis:value  "800"^^xsd:float
+                                                           ] ;
+                                     epcis:sensorReport    [ epcis:type   gs1:MT-Speed ;
+                                                             epcis:uom    "KMH" ;
+                                                             epcis:value  "160"^^xsd:float
+                                                           ] ;
+                                     epcis:sensorReport    [ epcis:type   gs1:MT-Humidity ;
+                                                             epcis:uom    "A93" ;
+                                                             epcis:value  "1.21E1"^^xsd:float
+                                                           ] ;
+                                     epcis:sensorReport    [ epcis:type   gs1:MT-Temperature ;
+                                                             epcis:uom    "CEL" ;
+                                                             epcis:value  "26"^^xsd:float
+                                                           ]
+                                   ] ;
+        epcis:sensorElementList    [ epcis:sensorMetadata  [ epcis:deviceID        <urn:epc:id:giai:4000001.111> ;
+                                                             epcis:deviceMetadata  <https://id.gs1.org/giai/4000001111> ;
+                                                             epcis:rawData         <https://example.org/giai/401234599999> ;
+                                                             epcis:time            "2019-04-02T14:55:00.000+01:00"^^xsd:dateTime
+                                                           ] ;
+                                     epcis:sensorReport    [ epcis:type   gs1:MT-Illuminance ;
+                                                             epcis:uom    "LUX" ;
+                                                             epcis:value  "802"^^xsd:float
+                                                           ] ;
+                                     epcis:sensorReport    [ epcis:type   gs1:MT-Speed ;
+                                                             epcis:uom    "KMH" ;
+                                                             epcis:value  "162"^^xsd:float
+                                                           ] ;
+                                     epcis:sensorReport    [ epcis:type   gs1:MT-Humidity ;
+                                                             epcis:uom    "A93" ;
+                                                             epcis:value  "1.22E1"^^xsd:float
+                                                           ] ;
+                                     epcis:sensorReport    [ epcis:type   gs1:MT-Temperature ;
+                                                             epcis:uom    "CEL" ;
+                                                             epcis:value  "2.62E1"^^xsd:float
+                                                           ]
+                                   ] .
+
+[ a                epcis:EPCISDocument ;
+  dcterms:created  "2005-07-11T11:30:47.0Z"^^xsd:dateTime ;
+  dcterms:format   "application/ld+json" ;
+  owl:versionInfo  "2.0" ;
+  epcis:epcisBody  [ epcis:eventList  <ni:///sha-256;e84840e98e15b9c86168ce85ca277af4241dddd3b658f9650a00096c2a09c2f3?ver=CBV2.0> ]
+] .

--- a/Turtle/WithSensorData/SensorDataExample2.ttl
+++ b/Turtle/WithSensorData/SensorDataExample2.ttl
@@ -1,0 +1,56 @@
+@prefix epcis: <https://ns.gs1.org/epcis/> .
+@prefix gs1:   <https://gs1.org/voc/> .
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix vtype: <urn:epcglobal:epcis:vtype:> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix example: <http://ns.example.com/epcis/> .
+@prefix cbvmda: <urn:epcglobal:cbv:mda:> .
+
+<ni:///sha-256;0301ed4c40065cde36eb9cc80780312d903a031a91d105639df4e649a9d01200?ver=CBV2.0>
+        a                          epcis:ObjectEvent ;
+        epcis:action               "OBSERVE" ;
+        epcis:bizStep              <urn:epcglobal:cbv:bizstep:inspecting> ;
+        epcis:epcList              <urn:epc:id:sgtin:4012345.011111.9876> ;
+        epcis:eventTime            "2019-04-02T15:00:00.000+01:00"^^xsd:dateTime ;
+        epcis:eventTimeZoneOffset  "+01:00" ;
+        epcis:readPoint            <urn:epc:id:sgln:4012345.00005.0> ;
+        epcis:sensorElementList    [ epcis:sensorMetadata  [ epcis:bizRules        <https://example.com/gdti/4012345000054987> ;
+                                                             epcis:deviceID        <urn:epc:id:giai:4000001.111> ;
+                                                             epcis:deviceMetadata  <https://id.gs1.org/giai/4000001111> ;
+                                                             epcis:endTime         "2019-04-02T14:55:00.000+01:00"^^xsd:dateTime ;
+                                                             epcis:rawData         <https://example.org/giai/401234599999> ;
+                                                             epcis:startTime       "2019-04-02T13:55:01.000+01:00"^^xsd:dateTime
+                                                           ] ;
+                                     epcis:sensorReport    [ epcis:maxValue  "802"^^xsd:float ;
+                                                             epcis:minValue  "800"^^xsd:float ;
+                                                             epcis:type      gs1:MT-Illuminance ;
+                                                             epcis:uom       "LUX"
+                                                           ] ;
+                                     epcis:sensorReport    [ epcis:maxValue  "162"^^xsd:float ;
+                                                             epcis:minValue  "160"^^xsd:float ;
+                                                             epcis:type      gs1:MT-Speed ;
+                                                             epcis:uom       "KMH"
+                                                           ] ;
+                                     epcis:sensorReport    [ epcis:maxValue  "1.22E1"^^xsd:float ;
+                                                             epcis:minValue  "1.21E1"^^xsd:float ;
+                                                             epcis:type      gs1:MT-Humidity ;
+                                                             epcis:uom       "A93"
+                                                           ] ;
+                                     epcis:sensorReport    [ epcis:maxValue   "2.62E1"^^xsd:float ;
+                                                             epcis:meanValue  "2.61E1"^^xsd:float ;
+                                                             epcis:minValue   "26"^^xsd:float ;
+                                                             epcis:sDev       "1.0E-1"^^xsd:float ;
+                                                             epcis:type       gs1:MT-Temperature ;
+                                                             epcis:uom        "CEL"
+                                                           ]
+                                   ] .
+
+[ a                epcis:EPCISDocument ;
+  dcterms:created  "2005-07-11T11:30:47.0Z"^^xsd:dateTime ;
+  dcterms:format   "application/ld+json" ;
+  owl:versionInfo  "2.0" ;
+  epcis:epcisBody  [ epcis:eventList  <ni:///sha-256;0301ed4c40065cde36eb9cc80780312d903a031a91d105639df4e649a9d01200?ver=CBV2.0> ]
+] .

--- a/Turtle/WithSensorData/SensorDataExample3.ttl
+++ b/Turtle/WithSensorData/SensorDataExample3.ttl
@@ -1,0 +1,39 @@
+@prefix epcis: <https://ns.gs1.org/epcis/> .
+@prefix gs1:   <https://gs1.org/voc/> .
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix vtype: <urn:epcglobal:epcis:vtype:> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix example: <http://ns.example.com/epcis/> .
+@prefix cbvmda: <urn:epcglobal:cbv:mda:> .
+
+<ni:///sha-256;b507b2720c96cd99855eabb101e8617d48622eff4ceaad0a416b3c10dfd316ee?ver=CBV2.0>
+        a                          epcis:ObjectEvent ;
+        epcis:action               "OBSERVE" ;
+        epcis:bizStep              <urn:epcglobal:cbv:bizstep:inspecting> ;
+        epcis:eventTime            "2019-04-02T15:00:00.000+01:00"^^xsd:dateTime ;
+        epcis:eventTimeZoneOffset  "+01:00" ;
+        epcis:readPoint            <urn:epc:id:sgln:4012345.00005.0> ;
+        epcis:sensorElementList    [ epcis:sensorMetadata  [ epcis:endTime    "2019-04-02T14:59:59.999+01:00"^^xsd:dateTime ;
+                                                             epcis:startTime  "2019-04-01T15:00:00.000+01:00"^^xsd:dateTime
+                                                           ] ;
+                                     epcis:sensorReport    [ epcis:maxValue  "7.25E1"^^xsd:float ;
+                                                             epcis:minValue  "6.92E1"^^xsd:float ;
+                                                             epcis:type      gs1:MT-Humidity ;
+                                                             epcis:uom       "A93"
+                                                           ] ;
+                                     epcis:sensorReport    [ epcis:maxValue  "1.38E1"^^xsd:float ;
+                                                             epcis:minValue  "1.24E1"^^xsd:float ;
+                                                             epcis:type      gs1:MT-Temperature ;
+                                                             epcis:uom       "CEL"
+                                                           ]
+                                   ] .
+
+[ a                epcis:EPCISDocument ;
+  dcterms:created  "2005-07-11T11:30:47.0Z"^^xsd:dateTime ;
+  dcterms:format   "application/ld+json" ;
+  owl:versionInfo  "2.0" ;
+  epcis:epcisBody  [ epcis:eventList  <ni:///sha-256;b507b2720c96cd99855eabb101e8617d48622eff4ceaad0a416b3c10dfd316ee?ver=CBV2.0> ]
+] .

--- a/Turtle/WithSensorData/SensorDataExample4.ttl
+++ b/Turtle/WithSensorData/SensorDataExample4.ttl
@@ -1,0 +1,59 @@
+@prefix epcis: <https://ns.gs1.org/epcis/> .
+@prefix gs1:   <https://gs1.org/voc/> .
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix vtype: <urn:epcglobal:epcis:vtype:> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix example: <http://ns.example.com/epcis/> .
+@prefix cbvmda: <urn:epcglobal:cbv:mda:> .
+
+[ a                epcis:EPCISDocument ;
+  dcterms:created  "2005-07-11T11:30:47.0Z"^^xsd:dateTime ;
+  dcterms:format   "application/ld+json" ;
+  owl:versionInfo  "2.0" ;
+  epcis:epcisBody  [ epcis:eventList  <ni:///sha-256;7ff1501099b3f5890d310d703fb9f57e251bba0c57d3c049fab590b50323a8e7?ver=CBV2.0> ]
+] .
+
+<ni:///sha-256;7ff1501099b3f5890d310d703fb9f57e251bba0c57d3c049fab590b50323a8e7?ver=CBV2.0>
+        a                          epcis:ObjectEvent ;
+        epcis:action               "OBSERVE" ;
+        epcis:bizStep              <urn:epcglobal:cbv:bizstep:inspecting> ;
+        epcis:eventTime            "2019-04-02T15:00:00.000+01:00"^^xsd:dateTime ;
+        epcis:eventTimeZoneOffset  "+01:00" ;
+        epcis:quantityList         [ epcis:epcClass  <urn:epc:class:lgtin:4023333.002000.2019-10-07> ;
+                                     epcis:quantity  "150"^^xsd:decimal ;
+                                     epcis:uom       "KGM"
+                                   ] ;
+        epcis:readPoint            <urn:epc:id:sgln:4012345.00005.0> ;
+        epcis:sensorElementList    [ epcis:sensorMetadata  [ epcis:time  "2019-04-02T14:55:00.000+01:00"^^xsd:dateTime ] ;
+                                     epcis:sensorReport    [ epcis:deviceID        <urn:epc:id:giai:4000001.444> ;
+                                                             epcis:deviceMetadata  <https://id.gs1.org/giai/4000001444> ;
+                                                             epcis:rawData         <https://example.org/giai/401234599999> ;
+                                                             epcis:type            gs1:MT-Illuminance ;
+                                                             epcis:uom             "LUX" ;
+                                                             epcis:value           "800"^^xsd:float
+                                                           ] ;
+                                     epcis:sensorReport    [ epcis:deviceID        <urn:epc:id:giai:4000001.333> ;
+                                                             epcis:deviceMetadata  <https://id.gs1.org/giai/4000001333> ;
+                                                             epcis:rawData         <https://example.org/giai/401234599999> ;
+                                                             epcis:type            gs1:MT-Speed ;
+                                                             epcis:uom             "KMH" ;
+                                                             epcis:value           "160"^^xsd:float
+                                                           ] ;
+                                     epcis:sensorReport    [ epcis:deviceID        <urn:epc:id:giai:4000001.222> ;
+                                                             epcis:deviceMetadata  <https://id.gs1.org/giai/4000001222> ;
+                                                             epcis:rawData         <https://example.org/giai/401234599999> ;
+                                                             epcis:type            gs1:MT-Humidity ;
+                                                             epcis:uom             "A93" ;
+                                                             epcis:value           "1.21E1"^^xsd:float
+                                                           ] ;
+                                     epcis:sensorReport    [ epcis:deviceID        <urn:epc:id:giai:4000001.111> ;
+                                                             epcis:deviceMetadata  <https://id.gs1.org/giai/4000001111> ;
+                                                             epcis:rawData         <https://example.org/giai/401234599999> ;
+                                                             epcis:type            gs1:MT-Temperature ;
+                                                             epcis:uom             "CEL" ;
+                                                             epcis:value           "26"^^xsd:float
+                                                           ]
+                                   ] .

--- a/Turtle/WithSensorData/SensorDataExample5.ttl
+++ b/Turtle/WithSensorData/SensorDataExample5.ttl
@@ -1,0 +1,60 @@
+@prefix epcis: <https://ns.gs1.org/epcis/> .
+@prefix gs1:   <https://gs1.org/voc/> .
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix vtype: <urn:epcglobal:epcis:vtype:> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix example: <http://ns.example.com/epcis/> .
+@prefix cbvmda: <urn:epcglobal:cbv:mda:> .
+
+<ni:///sha-256;e13ff14a9b4f3dd11bba60315ed9b849eb8ddf4c5b1a9aa794cd250256730834?ver=CBV2.0>
+        a                          epcis:ObjectEvent ;
+        epcis:action               "OBSERVE" ;
+        epcis:bizStep              <urn:epcglobal:cbv:bizstep:inspecting> ;
+        epcis:epcList              <urn:epc:id:sgtin:4012345.011111.9876> ;
+        epcis:eventTime            "2019-04-02T15:00:00.000+01:00"^^xsd:dateTime ;
+        epcis:eventTimeZoneOffset  "+01:00" ;
+        epcis:readPoint            <urn:epc:id:sgln:4012345.00005.0> ;
+        epcis:sensorElementList    [ epcis:sensorMetadata  [ epcis:deviceID        <urn:epc:id:giai:4000001.111> ;
+                                                             epcis:deviceMetadata  <https://id.gs1.org/giai/4000001111>
+                                                           ] ;
+                                     epcis:sensorReport    [ epcis:time   "2019-04-02T14:55:00.000+01:00"^^xsd:dateTime ;
+                                                             epcis:type   gs1:MT-Temperature ;
+                                                             epcis:uom    "CEL" ;
+                                                             epcis:value  "2.65E1"^^xsd:float
+                                                           ] ;
+                                     epcis:sensorReport    [ epcis:time   "2019-04-02T14:45:00.000+01:00"^^xsd:dateTime ;
+                                                             epcis:type   gs1:MT-Temperature ;
+                                                             epcis:uom    "CEL" ;
+                                                             epcis:value  "2.64E1"^^xsd:float
+                                                           ] ;
+                                     epcis:sensorReport    [ epcis:time   "2019-04-02T14:35:00.000+01:00"^^xsd:dateTime ;
+                                                             epcis:type   gs1:MT-Temperature ;
+                                                             epcis:uom    "CEL" ;
+                                                             epcis:value  "2.63E1"^^xsd:float
+                                                           ] ;
+                                     epcis:sensorReport    [ epcis:time   "2019-04-02T14:25:00.000+01:00"^^xsd:dateTime ;
+                                                             epcis:type   gs1:MT-Temperature ;
+                                                             epcis:uom    "CEL" ;
+                                                             epcis:value  "2.62E1"^^xsd:float
+                                                           ] ;
+                                     epcis:sensorReport    [ epcis:time   "2019-04-02T14:15:00.000+01:00"^^xsd:dateTime ;
+                                                             epcis:type   gs1:MT-Temperature ;
+                                                             epcis:uom    "CEL" ;
+                                                             epcis:value  "2.61E1"^^xsd:float
+                                                           ] ;
+                                     epcis:sensorReport    [ epcis:time   "2019-04-02T14:05:00.000+01:00"^^xsd:dateTime ;
+                                                             epcis:type   gs1:MT-Temperature ;
+                                                             epcis:uom    "CEL" ;
+                                                             epcis:value  "26"^^xsd:float
+                                                           ]
+                                   ] .
+
+[ a                epcis:EPCISDocument ;
+  dcterms:created  "2005-07-11T11:30:47.0Z"^^xsd:dateTime ;
+  dcterms:format   "application/ld+json" ;
+  owl:versionInfo  "2.0" ;
+  epcis:epcisBody  [ epcis:eventList  <ni:///sha-256;e13ff14a9b4f3dd11bba60315ed9b849eb8ddf4c5b1a9aa794cd250256730834?ver=CBV2.0> ]
+] .

--- a/Turtle/WithSensorData/SensorDataExample6.ttl
+++ b/Turtle/WithSensorData/SensorDataExample6.ttl
@@ -1,0 +1,52 @@
+@prefix epcis: <https://ns.gs1.org/epcis/> .
+@prefix gs1:   <https://gs1.org/voc/> .
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix vtype: <urn:epcglobal:epcis:vtype:> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix example: <http://ns.example.com/epcis/> .
+@prefix cbvmda: <urn:epcglobal:cbv:mda:> .
+
+[ a                epcis:EPCISDocument ;
+  dcterms:created  "2005-07-11T11:30:47.0Z"^^xsd:dateTime ;
+  dcterms:format   "application/ld+json" ;
+  owl:versionInfo  "2.0" ;
+  epcis:epcisBody  [ epcis:eventList  <ni:///sha-256;6aca25c45463182fe3a1ebf60a6b81a165f061b58f4f3c202eb423234386b72e?ver=CBV2.0> ]
+] .
+
+<ni:///sha-256;6aca25c45463182fe3a1ebf60a6b81a165f061b58f4f3c202eb423234386b72e?ver=CBV2.0>
+        a                          epcis:ObjectEvent ;
+        epcis:action               "OBSERVE" ;
+        epcis:bizStep              <urn:epcglobal:cbv:bizstep:inspecting> ;
+        epcis:epcList              <urn:epc:id:sgtin:4012345.011111.9876> ;
+        epcis:eventTime            "2019-10-07T15:00:00.000+01:00"^^xsd:dateTime ;
+        epcis:eventTimeZoneOffset  "+01:00" ;
+        epcis:quantityList         [ epcis:epcClass  <urn:epc:class:lgtin:4023333.002000.2019-10-07> ;
+                                     epcis:quantity  "150"^^xsd:decimal ;
+                                     epcis:uom       "KGM"
+                                   ] ;
+        epcis:readPoint            <urn:epc:id:sgln:4012345.00005.0> ;
+        epcis:sensorElementList    [ example:furtherSensorData  [ example:measure2
+                                                       "0.987" ] ;
+                                     example:furtherSensorData  [ example:measure1
+                                                       "123.5" ] ;
+                                     epcis:sensorMetadata       [ example:someFurtherMetaData  "someText" ;
+                                                                  epcis:endTime                "2019-04-02T14:59:59.999+01:00"^^xsd:dateTime ;
+                                                                  epcis:startTime              "2019-04-01T15:00:00.000+01:00"^^xsd:dateTime
+                                                                ] ;
+                                     epcis:sensorReport         [ epcis:stringValue  "someSensorOutput" ;
+                                                                  epcis:type         example:someSensorProperty
+                                                                ] ;
+                                     epcis:sensorReport         [ example:cv       "123" ;
+                                                                  epcis:maxValue   "1.38E1"^^xsd:float ;
+                                                                  epcis:meanValue  "1.32E1"^^xsd:float ;
+                                                                  epcis:minValue   "1.24E1"^^xsd:float ;
+                                                                  epcis:percRank   "50"^^xsd:float ;
+                                                                  epcis:percValue  "1.27E1"^^xsd:float ;
+                                                                  epcis:sDev       "4.1E-1"^^xsd:float ;
+                                                                  epcis:type       gs1:MT-Temperature ;
+                                                                  epcis:uom        "CEL"
+                                                                ]
+                                   ] .

--- a/Turtle/WithSensorData/SensorDataExample7.ttl
+++ b/Turtle/WithSensorData/SensorDataExample7.ttl
@@ -1,0 +1,53 @@
+@prefix epcis: <https://ns.gs1.org/epcis/> .
+@prefix gs1:   <https://gs1.org/voc/> .
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix vtype: <urn:epcglobal:epcis:vtype:> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix example: <http://ns.example.com/epcis/> .
+@prefix cbvmda: <urn:epcglobal:cbv:mda:> .
+
+<ni:///sha-256;db924230b77cc4d9a7cea4968fd302b06598a2b63e1b0ea011b31d1b5f45e6ac?ver=CBV2.0>
+        a                          epcis:ObjectEvent ;
+        epcis:action               "OBSERVE" ;
+        epcis:bizStep              <urn:epcglobal:cbv:bizstep:inspecting> ;
+        epcis:epcList              <urn:epc:id:sgtin:4012345.011111.9876> ;
+        epcis:eventTime            "2019-10-07T16:00:00.000+01:00"^^xsd:dateTime ;
+        epcis:eventTimeZoneOffset  "+01:00" ;
+        epcis:readPoint            <urn:epc:id:sgln:4012345.00005.0> ;
+        epcis:sensorElementList    [ epcis:sensorMetadata  [ epcis:time  "2019-07-19T14:00:00.000+01:00"^^xsd:dateTime ] ;
+                                     epcis:sensorReport    [ epcis:deviceID  <urn:epc:id:giai:4000001.116> ;
+                                                             epcis:type      <rail:Mno> ;
+                                                             epcis:uriValue  <https://example.org/rail/someSectorSpecificValue>
+                                                           ] ;
+                                     epcis:sensorReport    [ epcis:deviceID        <urn:epc:id:giai:4000001.115> ;
+                                                             epcis:hexBinaryValue  "F0F0F0"^^xsd:hexBinary ;
+                                                             epcis:type            example:Jkl
+                                                           ] ;
+                                     epcis:sensorReport    [ epcis:deviceID     <urn:epc:id:giai:4000001.114> ;
+                                                             epcis:stringValue  "SomeString" ;
+                                                             epcis:type         example:Ghi
+                                                           ] ;
+                                     epcis:sensorReport    [ epcis:booleanValue  true ;
+                                                             epcis:deviceID      <urn:epc:id:giai:4000001.113> ;
+                                                             epcis:type          <rail:Def>
+                                                           ] ;
+                                     epcis:sensorReport    [ epcis:deviceID     <urn:epc:id:giai:4000001.112> ;
+                                                             epcis:stringValue  "111100001111000011110000" ;
+                                                             epcis:type         <rail:Abc>
+                                                           ] ;
+                                     epcis:sensorReport    [ epcis:deviceID  <urn:epc:id:giai:4000001.111> ;
+                                                             epcis:type      gs1:MT-Temperature ;
+                                                             epcis:uom       "CEL" ;
+                                                             epcis:value     "26"^^xsd:float
+                                                           ]
+                                   ] .
+
+[ a                epcis:EPCISDocument ;
+  dcterms:created  "2005-07-11T11:30:47.0Z"^^xsd:dateTime ;
+  dcterms:format   "application/ld+json" ;
+  owl:versionInfo  "2.0" ;
+  epcis:epcisBody  [ epcis:eventList  <ni:///sha-256;db924230b77cc4d9a7cea4968fd302b06598a2b63e1b0ea011b31d1b5f45e6ac?ver=CBV2.0> ]
+] .

--- a/Turtle/WithSensorData/SensorDataExample8.ttl
+++ b/Turtle/WithSensorData/SensorDataExample8.ttl
@@ -1,0 +1,88 @@
+@prefix epcis: <https://ns.gs1.org/epcis/> .
+@prefix gs1:   <https://gs1.org/voc/> .
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix vtype: <urn:epcglobal:epcis:vtype:> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix example: <http://ns.example.com/epcis/> .
+@prefix cbvmda: <urn:epcglobal:cbv:mda:> .
+
+[ a                epcis:EPCISDocument ;
+  dcterms:created  "2005-07-11T11:30:47.0Z"^^xsd:dateTime ;
+  dcterms:format   "application/ld+json" ;
+  owl:versionInfo  "2.0" ;
+  epcis:epcisBody  [ epcis:eventList  <ni:///sha-256;18454584ed96fbb533e4a69b01eefd1bff3edd1e80ef8598957111f4477a0a64?ver=CBV2.0> ]
+] .
+
+<ni:///sha-256;18454584ed96fbb533e4a69b01eefd1bff3edd1e80ef8598957111f4477a0a64?ver=CBV2.0>
+        a                          epcis:AggregationEvent ;
+        epcis:action               "ADD" ;
+        epcis:bizStep              <urn:epcglobal:cbv:bizstep:packing> ;
+        epcis:childQuantityList    [ epcis:epcClass  <urn:epc:class:lgtin:4012345.011111.1234> ;
+                                     epcis:quantity  "52"^^xsd:decimal ;
+                                     epcis:uom       "KGM"
+                                   ] ;
+        epcis:disposition          <urn:epcglobal:cbv:disp:in_progress> ;
+        epcis:eventTime            "2019-10-07T15:30:00.000+01:00"^^xsd:dateTime ;
+        epcis:eventTimeZoneOffset  "+01:00" ;
+        epcis:parentID             <urn:epc:id:sscc:4012345.0111111111> ;
+        epcis:readPoint            <urn:epc:id:sgln:4012345.00025.0> ;
+        epcis:sensorElementList    [ epcis:sensorReport
+                          [ epcis:stringValue  "someSensorOutput" ;
+                            epcis:type         example:someSensorProperty
+                          ] ;
+                  epcis:sensorReport  [ epcis:bizRules              <https://example.org/gdti/4012345000054987> ;
+                                        epcis:dataProcessingMethod  <https://example.com/gdti/4012345000054987> ;
+                                        epcis:deviceID              <urn:epc:id:giai:4000001.111> ;
+                                        epcis:deviceMetadata        <https://id.gs1.org/giai/4000001111> ;
+                                        epcis:rawData               <https://example.org/giai/401234599999> ;
+                                        epcis:time                  "2019-07-19T14:00:00.000+01:00"^^xsd:dateTime ;
+                                        epcis:type                  gs1:MT-Temperature ;
+                                        epcis:uom                   "CEL"
+                                      ] ] ;
+        epcis:sensorElementList    [ epcis:sensorMetadata  [ epcis:bizRules              <https://example.org/gdti/4012345000054987> ;
+                                                             epcis:dataProcessingMethod  <https://example.com/gdti/4012345000054987> ;
+                                                             epcis:deviceID              <urn:epc:id:giai:4000001.111> ;
+                                                             epcis:deviceMetadata        <https://id.gs1.org/giai/4000001111> ;
+                                                             epcis:rawData               <https://example.org/giai/401234599999> ;
+                                                             epcis:time                  "2019-07-19T14:00:00.000+01:00"^^xsd:dateTime
+                                                           ] ;
+                                     epcis:sensorReport    [ epcis:microorganism  <https://www.ncbi.nlm.nih.gov/taxonomy/1126011> ;
+                                                             epcis:type           gs1:MT-Molar_concentration ;
+                                                             epcis:uom            "C35" ;
+                                                             epcis:value          "5.0E-2"^^xsd:float
+                                                           ] ;
+                                     epcis:sensorReport    [ epcis:chemicalSubstance  <https://identifiers.org/inchikey:CZMRCDWAGMRECN-UGDNZRGBSA-N> ;
+                                                             epcis:type               gs1:MT-Molar_concentration ;
+                                                             epcis:uom                "C35" ;
+                                                             epcis:value              "1.8E-1"^^xsd:float
+                                                           ] ;
+                                     epcis:sensorReport    [ epcis:type   gs1:MT-Humidity ;
+                                                             epcis:uom    "A93" ;
+                                                             epcis:value  "1.21E1"^^xsd:float
+                                                           ]
+                                   ] ;
+        epcis:sensorElementList    [ example:furtherSensorData  [ example:measure1
+                                                       "123.5" ] ;
+                                     example:furtherSensorData  [ example:measure2
+                                                       "0.987" ] ;
+                                     epcis:sensorMetadata       [ example:someFurtherMetaData  "someText" ;
+                                                                  epcis:endTime                "2019-04-02T14:59:59.999+01:00"^^xsd:dateTime ;
+                                                                  epcis:startTime              "2019-04-01T15:00:00.000+01:00"^^xsd:dateTime
+                                                                ] ;
+                                     epcis:sensorReport         [ epcis:stringValue  "someSensorOutput" ;
+                                                                  epcis:type         example:someSensorProperty
+                                                                ] ;
+                                     epcis:sensorReport         [ example:cv       "123" ;
+                                                                  epcis:maxValue   "1.38E1"^^xsd:float ;
+                                                                  epcis:meanValue  "1.32E1"^^xsd:float ;
+                                                                  epcis:minValue   "1.24E1"^^xsd:float ;
+                                                                  epcis:percRank   "50"^^xsd:float ;
+                                                                  epcis:percValue  "1.27E1"^^xsd:float ;
+                                                                  epcis:sDev       "4.1E-1"^^xsd:float ;
+                                                                  epcis:type       gs1:MT-Temperature ;
+                                                                  epcis:uom        "CEL"
+                                                                ]
+                                   ] .

--- a/Turtle/prefixes.ttl
+++ b/Turtle/prefixes.ttl
@@ -1,0 +1,11 @@
+@prefix epcis:   <https://ns.gs1.org/epcis/> .
+@prefix vtype:   <urn:epcglobal:epcis:vtype:> .
+@prefix cbvmda:  <urn:epcglobal:cbv:mda:> .
+
+@prefix gs1:     <https://gs1.org/voc/> .
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl:     <http://www.w3.org/2002/07/owl#> .
+@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix example: <http://ns.example.com/epcis/> .

--- a/Turtle/prefixes.ttl
+++ b/Turtle/prefixes.ttl
@@ -8,4 +8,5 @@
 @prefix owl:     <http://www.w3.org/2002/07/owl#> .
 @prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
-@prefix example: <http://ns.example.com/epcis/> .
+@prefix example1: <http://ns.example.com/epcis/> .
+@prefix example2: <http://epcis.example.com/ns/> .

--- a/Turtle/prefixes.ttl
+++ b/Turtle/prefixes.ttl
@@ -12,3 +12,10 @@
 @prefix example1: <http://ns.example.com/epcis/> .
 @prefix example2: <http://epcis.example.com/ns/> .
 @prefix example-mda: <http://epcis.example.com/mda/> .
+
+epcis:bizStep     a puml:InlineProperty.
+epcis:disposition a puml:InlineProperty.
+epcis:reason      a puml:InlineProperty.
+epcis:readPoint   a puml:InlineProperty.
+epcis:bizLocation a puml:InlineProperty.
+epcis:epcList     a puml:InlineProperty.

--- a/Turtle/prefixes.ttl
+++ b/Turtle/prefixes.ttl
@@ -1,4 +1,5 @@
 @prefix epcis:   <https://ns.gs1.org/epcis/> .
+@prefix md:      <https://ns.gs1.org/epcismd/> .
 @prefix vtype:   <urn:epcglobal:epcis:vtype:> .
 @prefix cbvmda:  <urn:epcglobal:cbv:mda:> .
 
@@ -10,3 +11,4 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix example1: <http://ns.example.com/epcis/> .
 @prefix example2: <http://epcis.example.com/ns/> .
+@prefix example-mda: <http://epcis.example.com/mda/> .


### PR DESCRIPTION
convert all JSON and JSON-LD examples to RDF Turtle automatically for two purposes:
- Turtle is easier to read than JSON-LD
- To validate the faithfulness of the JSON-LD representation and check the details of the corresponding RDF
