### PR TITLE
Update EPCglobal-epcis-2_0.xsd to relax requirement that SBDH SHALL be present in EPCISHeader

### DIFF
--- a/XSD/EPCglobal-epcis-2_0.xsd
+++ b/XSD/EPCglobal-epcis-2_0.xsd
@@ -47,7 +47,7 @@ GS1 retains the right to make changes to this document at any time, without noti
               </xsd:documentation>
     </xsd:annotation>
     <xsd:sequence>
-      <xsd:element ref="sbdh:StandardBusinessDocumentHeader"/>
+      <xsd:element ref="sbdh:StandardBusinessDocumentHeader" minOccurs="0"/>
       <xsd:element name="extension" type="epcis:EPCISHeaderExtensionType" minOccurs="0"/>
       <xsd:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
     </xsd:sequence>


### PR DESCRIPTION
This proposed change is for relaxing the XSD requirement that the Standard Business Document Header (SBDH) SHALL be present IF the EPCISHeader is included for other purposes such as declaring trade item master data attributes. To close out Issue 290.

Forgive me if I am submitting this in an unsuitable way.