### PR TITLE
Fixing XSD problem - Unique Particle Attribution, Providing examples for Event Hash IDs and Full combination of fields

### DIFF
--- a/XML/WithEventHashID/event_with_identical_hash_id_1.xml
+++ b/XML/WithEventHashID/event_with_identical_hash_id_1.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!DOCTYPE project>
+<epcis:EPCISDocument schemaVersion="2.0"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:ext1="http://ext.com/ext1"
+	creationDate="2013-06-04T14:59:02.099+02:00"
+	xmlns:epcis="urn:epcglobal:epcis:xsd:2">
+	<EPCISBody>
+		<EventList>
+			<!-- A base event to be compared where its event id should be identical 
+				with those of other 7 events -->
+			<ObjectEvent>
+				<eventTime>2005-04-04T20:33:31.116-06:00</eventTime>
+				<eventTimeZoneOffset>-06:00</eventTimeZoneOffset>
+				<epcList>
+					<epc>urn:epc:id:sgtin:0614141.107346.2016</epc>
+					<epc>urn:epc:id:sgtin:0614141.107346.2017</epc>
+					<epc>urn:epc:id:sgtin:0614141.107346.2018</epc>
+				</epcList>
+				<action>ADD</action>
+				<bizStep>urn:epcglobal:cbv:bizstep:receiving</bizStep>
+				<disposition>urn:epcglobal:cbv:disp:in_progress</disposition>
+				<readPoint>
+					<id>urn:epc:id:sgln:0012345.11111.400</id>
+				</readPoint>
+				<bizLocation>
+					<id>urn:epc:id:sgln:0012345.11111.0</id>
+				</bizLocation>
+				<bizTransactionList>
+					<bizTransaction type="urn:epcglobal:cbv:btt:po">urn:epc:id:gdti:0614141.00001.1618034</bizTransaction>
+				</bizTransactionList>
+				<quantityList>
+					<quantityElement>
+						<epcClass>urn:epc:class:lgtin:4012345.012345.998877</epcClass>
+						<quantity>200</quantity>
+						<uom>KGM</uom>
+					</quantityElement>
+					<quantityElement>
+						<epcClass>urn:epc:class:lgtin:4012345.012345.998876</epcClass>
+						<quantity>300</quantity>
+						<uom>KGM</uom>
+					</quantityElement>
+				</quantityList>
+				<sourceList>
+					<source type="urn:epcglobal:cbv:sdt:location">urn:epc:id:sgln:4012345.00225.0</source>
+					<source type="urn:epcglobal:cbv:sdt:possessing_party">urn:epc:id:pgln:4012345.00225</source>
+					<source type="urn:epcglobal:cbv:sdt:owning_party">urn:epc:id:pgln:4012345.00225</source>
+				</sourceList>
+				<destinationList>
+					<destination type="urn:epcglobal:cbv:sdt:location">urn:epc:id:sgln:0614141.00777.0</destination>
+					<destination
+						type="urn:epcglobal:cbv:sdt:possessing_party">urn:epc:id:pgln:0614141.00777</destination>
+					<destination type="urn:epcglobal:cbv:sdt:owning_party">urn:epc:id:pgln:0614141.00777</destination>
+				</destinationList>
+				<sensorElementList>
+					<sensorElement>
+						<sensorMetadata
+							time="2019-04-02T14:05:00.000+01:00"
+							deviceID="urn:epc:id:giai:4000001.111"
+							deviceMetadata="https://id.gs1.org/giai/4000001111"
+							rawData="https://example.org/giai/401234599999"
+							startTime="2019-04-02T13:55:01.000+01:00"
+							endTime="2019-04-02T14:55:00.000+01:00"
+							bizRules="https://example.com/gdti/4012345000054987"
+							dataProcessingMethod="https://example.com/gdti/4012345000054987"
+							ext1:someFurtherMetadata="someText" />
+						<sensorReport value="26.0" type="gs1:Temperature"
+							component="example:x" stringValue="SomeString"
+							booleanValue="true" hexBinaryValue="f0f0f0"
+							uriValue="https://id.gs1.org/giai/4000001111" uom="CEL"
+							minValue="26.0" maxValue="26.2" sDev="0.1"
+							chemicalSubstance="https://identifiers.org/inchikey:CZMRCDWAGMRECN-UGDNZRGBSA-N"
+							microorganism="https://www.ncbi.nlm.nih.gov/taxonomy/1126011"
+							deviceID="urn:epc:id:giai:4000001.111"
+							deviceMetadata="https://id.gs1.org/giai/4000001111"
+							rawData="https://example.org/giai/401234599999"
+							time="2019-07-19T14:00:00.000+01:00" meanValue="13.2"
+							percRank="50" percValue="12.7"
+							dataProcessingMethod="https://example.com/gdti/4012345000054987"
+							ext1:someFurtherReportData="someText" />
+						<ext1:default>stringAsDefaultValue</ext1:default>
+						<ext1:int xsi:type="xsd:integer">10</ext1:int>
+						<ext1:float xsi:type="xsd:double">20</ext1:float>
+					</sensorElement>
+				</sensorElementList>
+				<persistentDisposition>
+					<unset>urn:epcglobal:cbv:disp:completeness_inferred</unset>
+					<set>urn:epcglobal:cbv:disp:completeness_verified</set>
+				</persistentDisposition>
+				<ilmd>
+					<ext1:default>stringAsDefaultValue</ext1:default>
+					<ext1:int xsi:type="xsd:integer">10</ext1:int>
+					<ext1:float xsi:type="xsd:double">20</ext1:float>
+				</ilmd>
+				<ext1:default>stringAsDefaultValue</ext1:default>
+				<ext1:int xsi:type="xsd:integer">10</ext1:int>
+				<ext1:float xsi:type="xsd:double">20</ext1:float>
+			</ObjectEvent>
+		</EventList>
+	</EPCISBody>
+</epcis:EPCISDocument>

--- a/XML/WithEventHashID/event_with_identical_hash_id_2.xml
+++ b/XML/WithEventHashID/event_with_identical_hash_id_2.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!DOCTYPE project>
+<epcis:EPCISDocument schemaVersion="2.0"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:ext1="http://ext.com/ext1"
+	creationDate="2013-06-04T14:59:02.099+02:00"
+	xmlns:epcis="urn:epcglobal:epcis:xsd:2">
+	<EPCISBody>
+		<EventList>
+			<!-- different time zone but exactly identical event -->
+			<ObjectEvent>
+				<eventTime>2005-04-04T21:33:31.116-05:00</eventTime>
+				<eventTimeZoneOffset>-05:00</eventTimeZoneOffset>
+				<epcList>
+					<epc>urn:epc:id:sgtin:0614141.107346.2016</epc>
+					<epc>urn:epc:id:sgtin:0614141.107346.2017</epc>
+					<epc>urn:epc:id:sgtin:0614141.107346.2018</epc>
+				</epcList>
+				<action>ADD</action>
+				<bizStep>urn:epcglobal:cbv:bizstep:receiving</bizStep>
+				<disposition>urn:epcglobal:cbv:disp:in_progress</disposition>
+				<readPoint>
+					<id>urn:epc:id:sgln:0012345.11111.400</id>
+				</readPoint>
+				<bizLocation>
+					<id>urn:epc:id:sgln:0012345.11111.0</id>
+				</bizLocation>
+				<bizTransactionList>
+					<bizTransaction type="urn:epcglobal:cbv:btt:po">urn:epc:id:gdti:0614141.00001.1618034</bizTransaction>
+				</bizTransactionList>
+				<quantityList>
+					<quantityElement>
+						<epcClass>urn:epc:class:lgtin:4012345.012345.998877</epcClass>
+						<quantity>200</quantity>
+						<uom>KGM</uom>
+					</quantityElement>
+					<quantityElement>
+						<epcClass>urn:epc:class:lgtin:4012345.012345.998876</epcClass>
+						<quantity>300</quantity>
+						<uom>KGM</uom>
+					</quantityElement>
+				</quantityList>
+				<sourceList>
+					<source type="urn:epcglobal:cbv:sdt:location">urn:epc:id:sgln:4012345.00225.0</source>
+					<source type="urn:epcglobal:cbv:sdt:possessing_party">urn:epc:id:pgln:4012345.00225</source>
+					<source type="urn:epcglobal:cbv:sdt:owning_party">urn:epc:id:pgln:4012345.00225</source>
+				</sourceList>
+				<destinationList>
+					<destination type="urn:epcglobal:cbv:sdt:location">urn:epc:id:sgln:0614141.00777.0</destination>
+					<destination
+						type="urn:epcglobal:cbv:sdt:possessing_party">urn:epc:id:pgln:0614141.00777</destination>
+					<destination type="urn:epcglobal:cbv:sdt:owning_party">urn:epc:id:pgln:0614141.00777</destination>
+				</destinationList>
+				<sensorElementList>
+					<sensorElement>
+						<sensorMetadata
+							time="2019-04-02T14:05:00.000+01:00"
+							deviceID="urn:epc:id:giai:4000001.111"
+							deviceMetadata="https://id.gs1.org/giai/4000001111"
+							rawData="https://example.org/giai/401234599999"
+							startTime="2019-04-02T13:55:01.000+01:00"
+							endTime="2019-04-02T14:55:00.000+01:00"
+							bizRules="https://example.com/gdti/4012345000054987"
+							dataProcessingMethod="https://example.com/gdti/4012345000054987"
+							ext1:someFurtherMetadata="someText" />
+						<sensorReport value="26.0" type="gs1:Temperature"
+							component="example:x" stringValue="SomeString"
+							booleanValue="true" hexBinaryValue="f0f0f0"
+							uriValue="https://id.gs1.org/giai/4000001111" uom="CEL"
+							minValue="26.0" maxValue="26.2" sDev="0.1"
+							chemicalSubstance="https://identifiers.org/inchikey:CZMRCDWAGMRECN-UGDNZRGBSA-N"
+							microorganism="https://www.ncbi.nlm.nih.gov/taxonomy/1126011"
+							deviceID="urn:epc:id:giai:4000001.111"
+							deviceMetadata="https://id.gs1.org/giai/4000001111"
+							rawData="https://example.org/giai/401234599999"
+							time="2019-07-19T14:00:00.000+01:00" meanValue="13.2"
+							percRank="50" percValue="12.7"
+							dataProcessingMethod="https://example.com/gdti/4012345000054987"
+							ext1:someFurtherReportData="someText" />
+						<ext1:default>stringAsDefaultValue</ext1:default>
+						<ext1:int xsi:type="xsd:integer">10</ext1:int>
+						<ext1:float xsi:type="xsd:double">20</ext1:float>
+					</sensorElement>
+				</sensorElementList>
+				<persistentDisposition>
+					<unset>urn:epcglobal:cbv:disp:completeness_inferred</unset>
+					<set>urn:epcglobal:cbv:disp:completeness_verified</set>
+				</persistentDisposition>
+				<ilmd>
+					<ext1:default>stringAsDefaultValue</ext1:default>
+					<ext1:int xsi:type="xsd:integer">10</ext1:int>
+					<ext1:float xsi:type="xsd:double">20</ext1:float>
+				</ilmd>
+				<ext1:default>stringAsDefaultValue</ext1:default>
+				<ext1:int xsi:type="xsd:integer">10</ext1:int>
+				<ext1:float xsi:type="xsd:double">20</ext1:float>
+			</ObjectEvent>
+		</EventList>
+	</EPCISBody>
+</epcis:EPCISDocument>

--- a/XML/WithEventHashID/event_with_identical_hash_id_3.xml
+++ b/XML/WithEventHashID/event_with_identical_hash_id_3.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!DOCTYPE project>
+<epcis:EPCISDocument schemaVersion="2.0"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:ext1="http://ext.com/ext1"
+	creationDate="2013-06-04T14:59:02.099+02:00"
+	xmlns:epcis="urn:epcglobal:epcis:xsd:2">
+	<EPCISBody>
+		<EventList>
+			<!-- epc shuffled -->
+			<ObjectEvent>
+				<eventTime>2005-04-04T20:33:31.116-06:00</eventTime>
+				<eventTimeZoneOffset>-06:00</eventTimeZoneOffset>
+				<epcList>
+					<epc>urn:epc:id:sgtin:0614141.107346.2017</epc>
+					<epc>urn:epc:id:sgtin:0614141.107346.2016</epc>
+					<epc>urn:epc:id:sgtin:0614141.107346.2018</epc>
+				</epcList>
+				<action>ADD</action>
+				<bizStep>urn:epcglobal:cbv:bizstep:receiving</bizStep>
+				<disposition>urn:epcglobal:cbv:disp:in_progress</disposition>
+				<readPoint>
+					<id>urn:epc:id:sgln:0012345.11111.400</id>
+				</readPoint>
+				<bizLocation>
+					<id>urn:epc:id:sgln:0012345.11111.0</id>
+				</bizLocation>
+				<bizTransactionList>
+					<bizTransaction type="urn:epcglobal:cbv:btt:po">urn:epc:id:gdti:0614141.00001.1618034</bizTransaction>
+				</bizTransactionList>
+				<quantityList>
+					<quantityElement>
+						<epcClass>urn:epc:class:lgtin:4012345.012345.998877</epcClass>
+						<quantity>200</quantity>
+						<uom>KGM</uom>
+					</quantityElement>
+					<quantityElement>
+						<epcClass>urn:epc:class:lgtin:4012345.012345.998876</epcClass>
+						<quantity>300</quantity>
+						<uom>KGM</uom>
+					</quantityElement>
+				</quantityList>
+				<sourceList>
+					<source type="urn:epcglobal:cbv:sdt:location">urn:epc:id:sgln:4012345.00225.0</source>
+					<source type="urn:epcglobal:cbv:sdt:possessing_party">urn:epc:id:pgln:4012345.00225</source>
+					<source type="urn:epcglobal:cbv:sdt:owning_party">urn:epc:id:pgln:4012345.00225</source>
+				</sourceList>
+				<destinationList>
+					<destination type="urn:epcglobal:cbv:sdt:location">urn:epc:id:sgln:0614141.00777.0</destination>
+					<destination
+						type="urn:epcglobal:cbv:sdt:possessing_party">urn:epc:id:pgln:0614141.00777</destination>
+					<destination type="urn:epcglobal:cbv:sdt:owning_party">urn:epc:id:pgln:0614141.00777</destination>
+				</destinationList>
+				<sensorElementList>
+					<sensorElement>
+						<sensorMetadata
+							time="2019-04-02T14:05:00.000+01:00"
+							deviceID="urn:epc:id:giai:4000001.111"
+							deviceMetadata="https://id.gs1.org/giai/4000001111"
+							rawData="https://example.org/giai/401234599999"
+							startTime="2019-04-02T13:55:01.000+01:00"
+							endTime="2019-04-02T14:55:00.000+01:00"
+							bizRules="https://example.com/gdti/4012345000054987"
+							dataProcessingMethod="https://example.com/gdti/4012345000054987"
+							ext1:someFurtherMetadata="someText" />
+						<sensorReport value="26.0" type="gs1:Temperature"
+							component="example:x" stringValue="SomeString"
+							booleanValue="true" hexBinaryValue="f0f0f0"
+							uriValue="https://id.gs1.org/giai/4000001111" uom="CEL"
+							minValue="26.0" maxValue="26.2" sDev="0.1"
+							chemicalSubstance="https://identifiers.org/inchikey:CZMRCDWAGMRECN-UGDNZRGBSA-N"
+							microorganism="https://www.ncbi.nlm.nih.gov/taxonomy/1126011"
+							deviceID="urn:epc:id:giai:4000001.111"
+							deviceMetadata="https://id.gs1.org/giai/4000001111"
+							rawData="https://example.org/giai/401234599999"
+							time="2019-07-19T14:00:00.000+01:00" meanValue="13.2"
+							percRank="50" percValue="12.7"
+							dataProcessingMethod="https://example.com/gdti/4012345000054987"
+							ext1:someFurtherReportData="someText" />
+						<ext1:default>stringAsDefaultValue</ext1:default>
+						<ext1:int xsi:type="xsd:integer">10</ext1:int>
+						<ext1:float xsi:type="xsd:double">20</ext1:float>
+					</sensorElement>
+				</sensorElementList>
+				<persistentDisposition>
+					<unset>urn:epcglobal:cbv:disp:completeness_inferred</unset>
+					<set>urn:epcglobal:cbv:disp:completeness_verified</set>
+				</persistentDisposition>
+				<ilmd>
+					<ext1:default>stringAsDefaultValue</ext1:default>
+					<ext1:int xsi:type="xsd:integer">10</ext1:int>
+					<ext1:float xsi:type="xsd:double">20</ext1:float>
+				</ilmd>
+				<ext1:default>stringAsDefaultValue</ext1:default>
+				<ext1:int xsi:type="xsd:integer">10</ext1:int>
+				<ext1:float xsi:type="xsd:double">20</ext1:float>
+			</ObjectEvent>
+		</EventList>
+	</EPCISBody>
+</epcis:EPCISDocument>

--- a/XML/WithEventHashID/event_with_identical_hash_id_4.xml
+++ b/XML/WithEventHashID/event_with_identical_hash_id_4.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!DOCTYPE project>
+<epcis:EPCISDocument schemaVersion="2.0"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:ext1="http://ext.com/ext1"
+	creationDate="2013-06-04T14:59:02.099+02:00"
+	xmlns:epcis="urn:epcglobal:epcis:xsd:2">
+	<EPCISBody>
+		<EventList>
+			<!-- quantity list shuffled -->
+			<ObjectEvent>
+				<eventTime>2005-04-04T20:33:31.116-06:00</eventTime>
+				<eventTimeZoneOffset>-06:00</eventTimeZoneOffset>
+				<epcList>
+					<epc>urn:epc:id:sgtin:0614141.107346.2016</epc>
+					<epc>urn:epc:id:sgtin:0614141.107346.2017</epc>
+					<epc>urn:epc:id:sgtin:0614141.107346.2018</epc>
+				</epcList>
+				<action>ADD</action>
+				<bizStep>urn:epcglobal:cbv:bizstep:receiving</bizStep>
+				<disposition>urn:epcglobal:cbv:disp:in_progress</disposition>
+				<readPoint>
+					<id>urn:epc:id:sgln:0012345.11111.400</id>
+				</readPoint>
+				<bizLocation>
+					<id>urn:epc:id:sgln:0012345.11111.0</id>
+				</bizLocation>
+				<bizTransactionList>
+					<bizTransaction type="urn:epcglobal:cbv:btt:po">urn:epc:id:gdti:0614141.00001.1618034</bizTransaction>
+				</bizTransactionList>
+				<quantityList>
+					<quantityElement>
+						<epcClass>urn:epc:class:lgtin:4012345.012345.998876</epcClass>
+						<quantity>300</quantity>
+						<uom>KGM</uom>
+					</quantityElement>
+					<quantityElement>
+						<epcClass>urn:epc:class:lgtin:4012345.012345.998877</epcClass>
+						<quantity>200</quantity>
+						<uom>KGM</uom>
+					</quantityElement>
+				</quantityList>
+				<sourceList>
+					<source type="urn:epcglobal:cbv:sdt:location">urn:epc:id:sgln:4012345.00225.0</source>
+					<source type="urn:epcglobal:cbv:sdt:possessing_party">urn:epc:id:pgln:4012345.00225</source>
+					<source type="urn:epcglobal:cbv:sdt:owning_party">urn:epc:id:pgln:4012345.00225</source>
+				</sourceList>
+				<destinationList>
+					<destination type="urn:epcglobal:cbv:sdt:location">urn:epc:id:sgln:0614141.00777.0</destination>
+					<destination
+						type="urn:epcglobal:cbv:sdt:possessing_party">urn:epc:id:pgln:0614141.00777</destination>
+					<destination type="urn:epcglobal:cbv:sdt:owning_party">urn:epc:id:pgln:0614141.00777</destination>
+				</destinationList>
+				<sensorElementList>
+					<sensorElement>
+						<sensorMetadata
+							time="2019-04-02T14:05:00.000+01:00"
+							deviceID="urn:epc:id:giai:4000001.111"
+							deviceMetadata="https://id.gs1.org/giai/4000001111"
+							rawData="https://example.org/giai/401234599999"
+							startTime="2019-04-02T13:55:01.000+01:00"
+							endTime="2019-04-02T14:55:00.000+01:00"
+							bizRules="https://example.com/gdti/4012345000054987"
+							dataProcessingMethod="https://example.com/gdti/4012345000054987"
+							ext1:someFurtherMetadata="someText" />
+						<sensorReport value="26.0" type="gs1:Temperature"
+							component="example:x" stringValue="SomeString"
+							booleanValue="true" hexBinaryValue="f0f0f0"
+							uriValue="https://id.gs1.org/giai/4000001111" uom="CEL"
+							minValue="26.0" maxValue="26.2" sDev="0.1"
+							chemicalSubstance="https://identifiers.org/inchikey:CZMRCDWAGMRECN-UGDNZRGBSA-N"
+							microorganism="https://www.ncbi.nlm.nih.gov/taxonomy/1126011"
+							deviceID="urn:epc:id:giai:4000001.111"
+							deviceMetadata="https://id.gs1.org/giai/4000001111"
+							rawData="https://example.org/giai/401234599999"
+							time="2019-07-19T14:00:00.000+01:00" meanValue="13.2"
+							percRank="50" percValue="12.7"
+							dataProcessingMethod="https://example.com/gdti/4012345000054987"
+							ext1:someFurtherReportData="someText" />
+						<ext1:default>stringAsDefaultValue</ext1:default>
+						<ext1:int xsi:type="xsd:integer">10</ext1:int>
+						<ext1:float xsi:type="xsd:double">20</ext1:float>
+					</sensorElement>
+				</sensorElementList>
+				<persistentDisposition>
+					<unset>urn:epcglobal:cbv:disp:completeness_inferred</unset>
+					<set>urn:epcglobal:cbv:disp:completeness_verified</set>
+				</persistentDisposition>
+				<ilmd>
+					<ext1:default>stringAsDefaultValue</ext1:default>
+					<ext1:int xsi:type="xsd:integer">10</ext1:int>
+					<ext1:float xsi:type="xsd:double">20</ext1:float>
+				</ilmd>
+				<ext1:default>stringAsDefaultValue</ext1:default>
+				<ext1:int xsi:type="xsd:integer">10</ext1:int>
+				<ext1:float xsi:type="xsd:double">20</ext1:float>
+			</ObjectEvent>
+		</EventList>
+	</EPCISBody>
+</epcis:EPCISDocument>

--- a/XML/WithEventHashID/event_with_identical_hash_id_5.xml
+++ b/XML/WithEventHashID/event_with_identical_hash_id_5.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!DOCTYPE project>
+<epcis:EPCISDocument schemaVersion="2.0"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:ext2="http://ext.com/ext1"
+	creationDate="2013-06-04T14:59:02.099+02:00"
+	xmlns:epcis="urn:epcglobal:epcis:xsd:2">
+	<EPCISBody>
+		<EventList>
+			<!-- difference namespace used -->
+			<ObjectEvent>
+				<eventTime>2005-04-04T20:33:31.116-06:00</eventTime>
+				<eventTimeZoneOffset>-06:00</eventTimeZoneOffset>
+				<epcList>
+					<epc>urn:epc:id:sgtin:0614141.107346.2016</epc>
+					<epc>urn:epc:id:sgtin:0614141.107346.2017</epc>
+					<epc>urn:epc:id:sgtin:0614141.107346.2018</epc>
+				</epcList>
+				<action>ADD</action>
+				<bizStep>urn:epcglobal:cbv:bizstep:receiving</bizStep>
+				<disposition>urn:epcglobal:cbv:disp:in_progress</disposition>
+				<readPoint>
+					<id>urn:epc:id:sgln:0012345.11111.400</id>
+				</readPoint>
+				<bizLocation>
+					<id>urn:epc:id:sgln:0012345.11111.0</id>
+				</bizLocation>
+				<bizTransactionList>
+					<bizTransaction type="urn:epcglobal:cbv:btt:po">urn:epc:id:gdti:0614141.00001.1618034</bizTransaction>
+				</bizTransactionList>
+				<quantityList>
+					<quantityElement>
+						<epcClass>urn:epc:class:lgtin:4012345.012345.998876</epcClass>
+						<quantity>300</quantity>
+						<uom>KGM</uom>
+					</quantityElement>
+					<quantityElement>
+						<epcClass>urn:epc:class:lgtin:4012345.012345.998877</epcClass>
+						<quantity>200</quantity>
+						<uom>KGM</uom>
+					</quantityElement>
+				</quantityList>
+				<sourceList>
+					<source type="urn:epcglobal:cbv:sdt:location">urn:epc:id:sgln:4012345.00225.0</source>
+					<source type="urn:epcglobal:cbv:sdt:possessing_party">urn:epc:id:pgln:4012345.00225</source>
+					<source type="urn:epcglobal:cbv:sdt:owning_party">urn:epc:id:pgln:4012345.00225</source>
+				</sourceList>
+				<destinationList>
+					<destination type="urn:epcglobal:cbv:sdt:location">urn:epc:id:sgln:0614141.00777.0</destination>
+					<destination
+						type="urn:epcglobal:cbv:sdt:possessing_party">urn:epc:id:pgln:0614141.00777</destination>
+					<destination type="urn:epcglobal:cbv:sdt:owning_party">urn:epc:id:pgln:0614141.00777</destination>
+				</destinationList>
+				<sensorElementList>
+					<sensorElement>
+						<sensorMetadata
+							time="2019-04-02T14:05:00.000+01:00"
+							deviceID="urn:epc:id:giai:4000001.111"
+							deviceMetadata="https://id.gs1.org/giai/4000001111"
+							rawData="https://example.org/giai/401234599999"
+							startTime="2019-04-02T13:55:01.000+01:00"
+							endTime="2019-04-02T14:55:00.000+01:00"
+							bizRules="https://example.com/gdti/4012345000054987"
+							dataProcessingMethod="https://example.com/gdti/4012345000054987"
+							ext2:someFurtherMetadata="someText" />
+						<sensorReport value="26.0" type="gs1:Temperature"
+							component="example:x" stringValue="SomeString"
+							booleanValue="true" hexBinaryValue="f0f0f0"
+							uriValue="https://id.gs1.org/giai/4000001111" uom="CEL"
+							minValue="26.0" maxValue="26.2" sDev="0.1"
+							chemicalSubstance="https://identifiers.org/inchikey:CZMRCDWAGMRECN-UGDNZRGBSA-N"
+							microorganism="https://www.ncbi.nlm.nih.gov/taxonomy/1126011"
+							deviceID="urn:epc:id:giai:4000001.111"
+							deviceMetadata="https://id.gs1.org/giai/4000001111"
+							rawData="https://example.org/giai/401234599999"
+							time="2019-07-19T14:00:00.000+01:00" meanValue="13.2"
+							percRank="50" percValue="12.7"
+							dataProcessingMethod="https://example.com/gdti/4012345000054987"
+							ext2:someFurtherReportData="someText" />
+						<ext2:default>stringAsDefaultValue</ext2:default>
+						<ext2:int xsi:type="xsd:integer">10</ext2:int>
+						<ext2:float xsi:type="xsd:double">20</ext2:float>
+					</sensorElement>
+				</sensorElementList>
+				<persistentDisposition>
+					<unset>urn:epcglobal:cbv:disp:completeness_inferred</unset>
+					<set>urn:epcglobal:cbv:disp:completeness_verified</set>
+				</persistentDisposition>
+				<ilmd>
+					<ext2:default>stringAsDefaultValue</ext2:default>
+					<ext2:int xsi:type="xsd:integer">10</ext2:int>
+					<ext2:float xsi:type="xsd:double">20</ext2:float>
+				</ilmd>
+				<ext2:default>stringAsDefaultValue</ext2:default>
+				<ext2:int xsi:type="xsd:integer">10</ext2:int>
+				<ext2:float xsi:type="xsd:double">20</ext2:float>
+			</ObjectEvent>
+		</EventList>
+	</EPCISBody>
+</epcis:EPCISDocument>

--- a/XML/WithEventHashID/event_with_identical_hash_id_6.xml
+++ b/XML/WithEventHashID/event_with_identical_hash_id_6.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!DOCTYPE project>
+<epcis:EPCISDocument schemaVersion="2.0"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:ext1="http://ext.com/ext1"
+	creationDate="2013-06-04T14:59:02.099+02:00"
+	xmlns:epcis="urn:epcglobal:epcis:xsd:2">
+	<EPCISBody>
+		<EventList>
+			<!-- use explicitly states string type of an extension field -->
+			<ObjectEvent>
+				<eventTime>2005-04-04T20:33:31.116-06:00</eventTime>
+				<eventTimeZoneOffset>-06:00</eventTimeZoneOffset>
+				<epcList>
+					<epc>urn:epc:id:sgtin:0614141.107346.2016</epc>
+					<epc>urn:epc:id:sgtin:0614141.107346.2017</epc>
+					<epc>urn:epc:id:sgtin:0614141.107346.2018</epc>
+				</epcList>
+				<action>ADD</action>
+				<bizStep>urn:epcglobal:cbv:bizstep:receiving</bizStep>
+				<disposition>urn:epcglobal:cbv:disp:in_progress</disposition>
+				<readPoint>
+					<id>urn:epc:id:sgln:0012345.11111.400</id>
+				</readPoint>
+				<bizLocation>
+					<id>urn:epc:id:sgln:0012345.11111.0</id>
+				</bizLocation>
+				<bizTransactionList>
+					<bizTransaction type="urn:epcglobal:cbv:btt:po">urn:epc:id:gdti:0614141.00001.1618034</bizTransaction>
+				</bizTransactionList>
+				<quantityList>
+					<quantityElement>
+						<epcClass>urn:epc:class:lgtin:4012345.012345.998877</epcClass>
+						<quantity>200</quantity>
+						<uom>KGM</uom>
+					</quantityElement>
+					<quantityElement>
+						<epcClass>urn:epc:class:lgtin:4012345.012345.998876</epcClass>
+						<quantity>300</quantity>
+						<uom>KGM</uom>
+					</quantityElement>
+				</quantityList>
+				<sourceList>
+					<source type="urn:epcglobal:cbv:sdt:location">urn:epc:id:sgln:4012345.00225.0</source>
+					<source type="urn:epcglobal:cbv:sdt:possessing_party">urn:epc:id:pgln:4012345.00225</source>
+					<source type="urn:epcglobal:cbv:sdt:owning_party">urn:epc:id:pgln:4012345.00225</source>
+				</sourceList>
+				<destinationList>
+					<destination type="urn:epcglobal:cbv:sdt:location">urn:epc:id:sgln:0614141.00777.0</destination>
+					<destination
+						type="urn:epcglobal:cbv:sdt:possessing_party">urn:epc:id:pgln:0614141.00777</destination>
+					<destination type="urn:epcglobal:cbv:sdt:owning_party">urn:epc:id:pgln:0614141.00777</destination>
+				</destinationList>
+				<sensorElementList>
+					<sensorElement>
+						<sensorMetadata
+							time="2019-04-02T14:05:00.000+01:00"
+							deviceID="urn:epc:id:giai:4000001.111"
+							deviceMetadata="https://id.gs1.org/giai/4000001111"
+							rawData="https://example.org/giai/401234599999"
+							startTime="2019-04-02T13:55:01.000+01:00"
+							endTime="2019-04-02T14:55:00.000+01:00"
+							bizRules="https://example.com/gdti/4012345000054987"
+							dataProcessingMethod="https://example.com/gdti/4012345000054987"
+							ext1:someFurtherMetadata="someText" />
+						<sensorReport value="26.0" type="gs1:Temperature"
+							component="example:x" stringValue="SomeString"
+							booleanValue="true" hexBinaryValue="f0f0f0"
+							uriValue="https://id.gs1.org/giai/4000001111" uom="CEL"
+							minValue="26.0" maxValue="26.2" sDev="0.1"
+							chemicalSubstance="https://identifiers.org/inchikey:CZMRCDWAGMRECN-UGDNZRGBSA-N"
+							microorganism="https://www.ncbi.nlm.nih.gov/taxonomy/1126011"
+							deviceID="urn:epc:id:giai:4000001.111"
+							deviceMetadata="https://id.gs1.org/giai/4000001111"
+							rawData="https://example.org/giai/401234599999"
+							time="2019-07-19T14:00:00.000+01:00" meanValue="13.2"
+							percRank="50" percValue="12.7"
+							dataProcessingMethod="https://example.com/gdti/4012345000054987"
+							ext1:someFurtherReportData="someText" />
+						<ext1:default>stringAsDefaultValue</ext1:default>
+						<ext1:int xsi:type="xsd:integer">10</ext1:int>
+						<ext1:float xsi:type="xsd:double">20</ext1:float>
+					</sensorElement>
+				</sensorElementList>
+				<persistentDisposition>
+					<unset>urn:epcglobal:cbv:disp:completeness_inferred</unset>
+					<set>urn:epcglobal:cbv:disp:completeness_verified</set>
+				</persistentDisposition>
+				<ilmd>
+					<ext1:default>stringAsDefaultValue</ext1:default>
+					<ext1:int xsi:type="xsd:integer">10</ext1:int>
+					<ext1:float xsi:type="xsd:double">20</ext1:float>
+				</ilmd>
+				<ext1:default xsi:type="xsd:string">stringAsDefaultValue</ext1:default>
+				<ext1:int xsi:type="xsd:integer">10</ext1:int>
+				<ext1:float xsi:type="xsd:double">20</ext1:float>
+			</ObjectEvent>
+		</EventList>
+	</EPCISBody>
+</epcis:EPCISDocument>

--- a/XML/WithEventHashID/event_with_identical_hash_id_7.json
+++ b/XML/WithEventHashID/event_with_identical_hash_id_7.json
@@ -1,13 +1,9 @@
 {
-  "@context": ["https://gs1.github.io/EPCIS/epcis-context.jsonld",{"ext1": "http://ext.com/ext1",
-    "ext2": "http://ext.com/ext2",
-    "ext3": "http://ext.com/ext3"}],
+  "@context": ["https://gs1.github.io/EPCIS/epcis-context.jsonld",{"ext1": "http://ext.com/ext1"}],
 
-  "id": "_:document1",
   "isA": "EPCISDocument",
   "schemaVersion": "2.0",
   "creationDate": "2005-07-11T11:30:47.0Z",
-  "format": "application/ld+json",
   "epcisBody": {
     "eventList": [
       {
@@ -40,7 +36,6 @@
         },
         "sensorElementList": [
           {
-            "isA": "epcis:SensorElement",
             "sensorMetadata": {
               "time": "2019-04-02T14:05:00.000+01:00", "deviceID": "urn:epc:id:giai:4000001.111",
               "deviceMetadata": "https://id.gs1.org/giai/4000001111", "rawData": "https://example.org/giai/401234599999",

--- a/XML/WithEventHashID/event_with_identical_hash_id_7.json
+++ b/XML/WithEventHashID/event_with_identical_hash_id_7.json
@@ -1,0 +1,77 @@
+{
+  "@context": ["https://gs1.github.io/EPCIS/epcis-context.jsonld",{"ext1": "http://ext.com/ext1",
+    "ext2": "http://ext.com/ext2",
+    "ext3": "http://ext.com/ext3"}],
+
+  "id": "_:document1",
+  "isA": "EPCISDocument",
+  "schemaVersion": "2.0",
+  "creationDate": "2005-07-11T11:30:47.0Z",
+  "format": "application/ld+json",
+  "epcisBody": {
+    "eventList": [
+      {
+        "isA": "ObjectEvent",
+        "action": "ADD",
+        "eventTime": "2005-04-04T20:33:31.116-06:00",
+        "eventTimeZoneOffset": "-06:00",
+        "epcList": [ "urn:epc:id:sgtin:0614141.107346.2016", "urn:epc:id:sgtin:0614141.107346.2017" ,"urn:epc:id:sgtin:0614141.107346.2018" ],
+        "bizStep": "urn:epcglobal:cbv:bizstep:receiving",
+        "disposition": "urn:epcglobal:cbv:disp:in_progress",
+        "readPoint": { "id" : "urn:epc:id:sgln:0012345.11111.400"},
+        "bizLocation": { "id" : "urn:epc:id:sgln:0012345.11111.0" } ,
+        "bizTransactionList": [ { "type": "urn:epcglobal:cbv:btt:po", "bizTransaction": "urn:epc:id:gdti:0614141.00001.1618034" }],
+        "quantityList": [ { "epcClass": "urn:epc:class:lgtin:4012345.012345.998877", "quantity": 200.0, "uom": "KGM" },
+          { "epcClass": "urn:epc:class:lgtin:4012345.012345.998876", "quantity": 300.0, "uom": "KGM" }],
+        "sourceList": [
+          { "type": "urn:epcglobal:cbv:sdt:location", "source": "urn:epc:id:sgln:4012345.00225.0" },
+          { "type": "urn:epcglobal:cbv:sdt:possessing_party", "source": "urn:epc:id:pgln:4012345.00225" },
+          { "type": "urn:epcglobal:cbv:sdt:owning_party", "source": "urn:epc:id:pgln:4012345.00225" }
+        ],
+        "destinationList": [
+          { "type": "urn:epcglobal:cbv:sdt:location", "destination": "urn:epc:id:sgln:0614141.00777.0" },
+          { "type": "urn:epcglobal:cbv:sdt:possessing_party", "destination": "urn:epc:id:pgln:0614141.00777" },
+          { "type": "urn:epcglobal:cbv:sdt:owning_party", "destination": "urn:epc:id:pgln:0614141.00777" }
+        ],
+        "ilmd": {
+          "ext1:default": "stringAsDefaultValue",
+          "ext1:int": 10,
+          "ext1:float": 20.0
+        },
+        "sensorElementList": [
+          {
+            "isA": "epcis:SensorElement",
+            "sensorMetadata": {
+              "time": "2019-04-02T14:05:00.000+01:00", "deviceID": "urn:epc:id:giai:4000001.111",
+              "deviceMetadata": "https://id.gs1.org/giai/4000001111", "rawData": "https://example.org/giai/401234599999",
+              "startTime": "2019-04-02T13:55:01.000+01:00", "endTime": "2019-04-02T14:55:00.000+01:00",
+              "bizRules": "https://example.com/gdti/4012345000054987", "dataProcessingMethod": "https://example.com/gdti/4012345000054987",
+              "ext1:someFurtherMetadata": "someText"
+            },
+            "sensorReport": [
+              {
+                "value": 26.0, "type": "gs1:Temperature", "component": "example:x", "stringValue": "SomeString",
+                "booleanValue": true, "hexBinaryValue": "f0f0f0", "uriValue": "https://id.gs1.org/giai/4000001111",
+                "uom": "CEL", "minValue": 26.0, "maxValue": 26.2, "sDev": 0.1, "chemicalSubstance": "https://identifiers.org/inchikey:CZMRCDWAGMRECN-UGDNZRGBSA-N",
+                "microorganism": "https://www.ncbi.nlm.nih.gov/taxonomy/1126011", "deviceID": "urn:epc:id:giai:4000001.111",
+                "deviceMetadata": "https://id.gs1.org/giai/4000001111", "rawData": "https://example.org/giai/401234599999",
+                "time": "2019-07-19T14:00:00.000+01:00", "meanValue": 13.2, "percRank": 50.0, "percValue": 12.7,
+                "dataProcessingMethod": "https://example.com/gdti/4012345000054987", "ext1:someFurtherReportData": "someText"
+              }
+            ],
+            "ext1:default":"stringAsDefaultValue",
+            "ext1:int": 10,
+            "ext1:float": 20.0
+          }
+        ],
+        "persistentDisposition": {
+          "unset": [ "urn:epcglobal:cbv:disp:completeness_inferred" ],
+          "set": [ "urn:epcglobal:cbv:disp:completeness_verified" ]
+        },
+        "ext1:default":"stringAsDefaultValue",
+        "ext1:int": 10,
+        "ext1:float": 20.0
+      }
+    ]
+  }
+}

--- a/XML/WithFullCombinationOfFields/aggregation_event_all_possible_fields.xml
+++ b/XML/WithFullCombinationOfFields/aggregation_event_all_possible_fields.xml
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!DOCTYPE project>
+<epcis:EPCISDocument schemaVersion="2.0"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:ext1="http://ext.com/ext1" xmlns:ext2="http://ext.com/ext2"
+	xmlns:ext3="http://ext.com/ext3"
+	creationDate="2013-06-04T14:59:02.099+02:00"
+	xmlns:epcis="urn:epcglobal:epcis:xsd:2">
+	<EPCISBody>
+		<EventList>
+			<AggregationEvent>
+				<eventTime>2013-06-08T14:58:56.591Z</eventTime>
+				<eventTimeZoneOffset>+02:00</eventTimeZoneOffset>
+				<parentID>urn:epc:id:sscc:0614141.1234567890</parentID>
+				<childEPCs>
+					<epc>urn:epc:id:sgtin:0614141.107346.2017</epc>
+					<epc>urn:epc:id:sgtin:0614141.107346.2018</epc>
+				</childEPCs>
+				<action>OBSERVE</action>
+				<bizStep>urn:epcglobal:cbv:bizstep:receiving</bizStep>
+				<disposition>urn:epcglobal:cbv:disp:in_progress</disposition>
+				<readPoint>
+					<id>urn:epc:id:sgln:0037000.00729.8202</id>
+				</readPoint>
+				<bizLocation>
+					<id>urn:epc:id:sgln:0037000.00729.8202</id>
+				</bizLocation>
+				<bizTransactionList>
+					<bizTransaction type="urn:epcglobal:cbv:btt:po">urn:epc:id:gdti:0614141.00001.1618034</bizTransaction>
+					<bizTransaction
+						type="urn:epcglobal:cbv:btt:pedigree">urn:epc:id:gsrn:0614141.0000010253</bizTransaction>
+				</bizTransactionList>
+				<childQuantityList>
+					<quantityElement>
+						<epcClass>urn:epc:idpat:sgtin:4012345.098765.*</epcClass>
+						<quantity>10</quantity>
+					</quantityElement>
+					<quantityElement>
+						<epcClass>urn:epc:class:lgtin:4012345.012345.998877</epcClass>
+						<quantity>200.5</quantity>
+						<uom>KGM</uom>
+					</quantityElement>
+				</childQuantityList>
+				<sourceList>
+					<source type="urn:epcglobal:cbv:sdt:location">urn:epc:id:sgln:4012345.00225.0</source>
+					<source type="urn:epcglobal:cbv:sdt:possessing_party">urn:epc:id:pgln:4012345.00225</source>
+					<source type="urn:epcglobal:cbv:sdt:owning_party">urn:epc:id:pgln:4012345.00225</source>
+				</sourceList>
+				<destinationList>
+					<destination type="urn:epcglobal:cbv:sdt:location">urn:epc:id:sgln:0614141.00777.0</destination>
+					<destination
+						type="urn:epcglobal:cbv:sdt:possessing_party">urn:epc:id:pgln:0614141.00777</destination>
+					<destination type="urn:epcglobal:cbv:sdt:owning_party">urn:epc:id:pgln:0614141.00777</destination>
+				</destinationList>
+				<sensorElementList>
+					<sensorElement>
+						<sensorMetadata
+							time="2019-04-02T14:05:00.000+01:00"
+							deviceID="urn:epc:id:giai:4000001.111"
+							deviceMetadata="https://id.gs1.org/giai/4000001111"
+							rawData="https://example.org/giai/401234599999"
+							startTime="2019-04-02T13:55:01.000+01:00"
+							endTime="2019-04-02T14:55:00.000+01:00"
+							bizRules="https://example.com/gdti/4012345000054987"
+							dataProcessingMethod="https://example.com/gdti/4012345000054987"
+							ext1:someFurtherMetadata="someText" />
+						<sensorReport value="26.0" type="gs1:Temperature"
+							component="example:x" stringValue="SomeString"
+							booleanValue="true" hexBinaryValue="f0f0f0"
+							uriValue="https://id.gs1.org/giai/4000001111" uom="CEL"
+							minValue="26.0" maxValue="26.2" sDev="0.1"
+							chemicalSubstance="https://identifiers.org/inchikey:CZMRCDWAGMRECN-UGDNZRGBSA-N"
+							microorganism="https://www.ncbi.nlm.nih.gov/taxonomy/1126011"
+							deviceID="urn:epc:id:giai:4000001.111"
+							deviceMetadata="https://id.gs1.org/giai/4000001111"
+							rawData="https://example.org/giai/401234599999"
+							time="2019-07-19T14:00:00.000+01:00" meanValue="13.2"
+							percRank="50" percValue="12.7"
+							dataProcessingMethod="https://example.com/gdti/4012345000054987"
+							ext1:someFurtherReportData="someText" />
+						<ext1:default>stringAsDefaultValue</ext1:default>
+						<ext1:int xsi:type="xsd:integer">10</ext1:int>
+						<ext1:float xsi:type="xsd:double">20</ext1:float>
+						<ext1:time xsi:type="xsd:dateTime">2013-06-08T14:58:56.591Z</ext1:time>
+						<ext1:boolean xsi:type="xsd:boolean">true</ext1:boolean>
+						<ext1:string xsi:type="xsd:string">string</ext1:string>
+						<ext1:object>
+							<ext2:string xsi:type="xsd:string">stringInObject</ext2:string>
+							<ext2:array xsi:type="xsd:integer">11</ext2:array>
+							<ext2:array xsi:type="xsd:double">21</ext2:array>
+							<ext2:array xsi:type="xsd:string">stringInArrayInObject</ext2:array>
+							<ext2:object>
+								<ext3:string xsi:type="xsd:string">stringInObjectInObject</ext3:string>
+							</ext2:object>
+						</ext1:object>
+						<ext1:array xsi:type="xsd:integer">12</ext1:array>
+						<ext1:array xsi:type="xsd:double">22</ext1:array>
+						<ext1:array xsi:type="xsd:dateTime">2013-06-08T14:58:56.591Z</ext1:array>
+						<ext1:array xsi:type="xsd:boolean">true</ext1:array>
+						<ext1:array xsi:type="xsd:string">stringInArray</ext1:array>
+						<ext1:array>
+							<ext1:object>
+								<ext2:int xsi:type="xsd:integer">13</ext2:int>
+								<ext2:string xsi:type="xsd:string">stringInObjectInArray</ext2:string>
+								<ext2:array xsi:type="xsd:integer">14</ext2:array>
+								<ext2:array xsi:type="xsd:double">23.0</ext2:array>
+								<ext2:array xsi:type="xsd:string">stringInArrayInObjectInArray</ext2:array>
+								<ext2:object>
+									<ext3:string xsi:type="xsd:string">stringInObjectInObjectInArray</ext3:string>
+								</ext2:object>
+							</ext1:object>
+						</ext1:array>
+					</sensorElement>
+				</sensorElementList>
+				<persistentDisposition>
+					<unset>urn:epcglobal:cbv:disp:completeness_inferred</unset>
+					<set>urn:epcglobal:cbv:disp:completeness_verified</set>
+				</persistentDisposition>
+				<ext1:default>stringAsDefaultValue</ext1:default>
+				<ext1:int xsi:type="xsd:integer">10</ext1:int>
+				<ext1:float xsi:type="xsd:double">20</ext1:float>
+				<ext1:time xsi:type="xsd:dateTime">2013-06-08T14:58:56.591Z</ext1:time>
+				<ext1:boolean xsi:type="xsd:boolean">true</ext1:boolean>
+				<ext1:string xsi:type="xsd:string">string</ext1:string>
+				<ext1:object>
+					<ext2:string xsi:type="xsd:string">stringInObject</ext2:string>
+					<ext2:array xsi:type="xsd:integer">11</ext2:array>
+					<ext2:array xsi:type="xsd:double">21</ext2:array>
+					<ext2:array xsi:type="xsd:string">stringInArrayInObject</ext2:array>
+					<ext2:object>
+						<ext3:string xsi:type="xsd:string">stringInObjectInObject</ext3:string>
+					</ext2:object>
+				</ext1:object>
+				<ext1:array xsi:type="xsd:integer">12</ext1:array>
+				<ext1:array xsi:type="xsd:double">22</ext1:array>
+				<ext1:array xsi:type="xsd:dateTime">2013-06-08T14:58:56.591Z</ext1:array>
+				<ext1:array xsi:type="xsd:boolean">true</ext1:array>
+				<ext1:array xsi:type="xsd:string">stringInArray</ext1:array>
+				<ext1:array>
+					<ext1:object>
+						<ext2:int xsi:type="xsd:integer">13</ext2:int>
+						<ext2:string xsi:type="xsd:string">stringInObjectInArray</ext2:string>
+						<ext2:array xsi:type="xsd:integer">14</ext2:array>
+						<ext2:array xsi:type="xsd:double">23.0</ext2:array>
+						<ext2:array xsi:type="xsd:string">stringInArrayInObjectInArray</ext2:array>
+						<ext2:object>
+							<ext3:string xsi:type="xsd:string">stringInObjectInObjectInArray</ext3:string>
+						</ext2:object>
+					</ext1:object>
+				</ext1:array>
+			</AggregationEvent>
+		</EventList>
+	</EPCISBody>
+</epcis:EPCISDocument>

--- a/XML/WithFullCombinationOfFields/association_event_all_possible_fields.xml
+++ b/XML/WithFullCombinationOfFields/association_event_all_possible_fields.xml
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!DOCTYPE project>
+<epcis:EPCISDocument schemaVersion="2.0"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:ext1="http://ext.com/ext1" xmlns:ext2="http://ext.com/ext2"
+	xmlns:ext3="http://ext.com/ext3"
+	creationDate="2013-06-04T14:59:02.099+02:00"
+	xmlns:epcis="urn:epcglobal:epcis:xsd:2">
+	<EPCISBody>
+		<EventList>
+			<AssociationEvent>
+				<eventTime>2019-11-01T14:00:00.000+01:00</eventTime>
+				<eventTimeZoneOffset>+01:00</eventTimeZoneOffset>
+				<parentID>urn:epc:id:grai:4012345.55555.987</parentID>
+				<childEPCs>
+					<epc>urn:epc:id:giai:4000001.12345</epc>
+					<epc>urn:epc:id:giai:4000001.12346</epc>
+				</childEPCs>
+				<childQuantityList>
+					<quantityElement>
+						<epcClass>urn:epc:idpat:sgtin:4012345.098765.*</epcClass>
+						<quantity>10</quantity>
+					</quantityElement>
+					<quantityElement>
+						<epcClass>urn:epc:class:lgtin:4012345.012345.998877</epcClass>
+						<quantity>200.5</quantity>
+						<uom>KGM</uom>
+					</quantityElement>
+				</childQuantityList>
+				<action>ADD</action>
+				<bizStep>urn:epcglobal:cbv:bizstep:assembling</bizStep>
+				<disposition>urn:epcglobal:cbv:disp:in_progress</disposition>
+				<readPoint>
+					<id>urn:epc:id:sgln:4012345.00001.0</id>
+				</readPoint>
+				<bizLocation>
+					<id>urn:epc:id:sgln:0614141.00888.0</id>
+				</bizLocation>
+				<bizTransactionList>
+					<bizTransaction type="urn:epcglobal:cbv:btt:po">urn:epc:id:gdti:0614141.00001.1618034</bizTransaction>
+					<bizTransaction
+						type="urn:epcglobal:cbv:btt:pedigree">urn:epc:id:gsrn:0614141.0000010253</bizTransaction>
+				</bizTransactionList>
+				<sourceList>
+					<source type="urn:epcglobal:cbv:sdt:location">urn:epc:id:sgln:4012345.00225.0</source>
+					<source type="urn:epcglobal:cbv:sdt:possessing_party">urn:epc:id:pgln:4012345.00225</source>
+					<source type="urn:epcglobal:cbv:sdt:owning_party">urn:epc:id:pgln:4012345.00225</source>
+				</sourceList>
+				<destinationList>
+					<destination type="urn:epcglobal:cbv:sdt:location">urn:epc:id:sgln:0614141.00777.0</destination>
+					<destination
+						type="urn:epcglobal:cbv:sdt:possessing_party">urn:epc:id:pgln:0614141.00777</destination>
+					<destination type="urn:epcglobal:cbv:sdt:owning_party">urn:epc:id:pgln:0614141.00777</destination>
+				</destinationList>
+				<sensorElementList>
+					<sensorElement>
+						<sensorMetadata
+							time="2019-04-02T14:05:00.000+01:00"
+							deviceID="urn:epc:id:giai:4000001.111"
+							deviceMetadata="https://id.gs1.org/giai/4000001111"
+							rawData="https://example.org/giai/401234599999"
+							startTime="2019-04-02T13:55:01.000+01:00"
+							endTime="2019-04-02T14:55:00.000+01:00"
+							bizRules="https://example.com/gdti/4012345000054987"
+							dataProcessingMethod="https://example.com/gdti/4012345000054987"
+							ext1:someFurtherMetadata="someText" />
+						<sensorReport value="26.0" type="gs1:Temperature"
+							component="example:x" stringValue="SomeString"
+							booleanValue="true" hexBinaryValue="f0f0f0"
+							uriValue="https://id.gs1.org/giai/4000001111" uom="CEL"
+							minValue="26.0" maxValue="26.2" sDev="0.1"
+							chemicalSubstance="https://identifiers.org/inchikey:CZMRCDWAGMRECN-UGDNZRGBSA-N"
+							microorganism="https://www.ncbi.nlm.nih.gov/taxonomy/1126011"
+							deviceID="urn:epc:id:giai:4000001.111"
+							deviceMetadata="https://id.gs1.org/giai/4000001111"
+							rawData="https://example.org/giai/401234599999"
+							time="2019-07-19T14:00:00.000+01:00" meanValue="13.2"
+							percRank="50" percValue="12.7"
+							dataProcessingMethod="https://example.com/gdti/4012345000054987"
+							ext1:someFurtherReportData="someText" />
+						<ext1:default>stringAsDefaultValue</ext1:default>
+						<ext1:int xsi:type="xsd:integer">10</ext1:int>
+						<ext1:float xsi:type="xsd:double">20</ext1:float>
+						<ext1:time xsi:type="xsd:dateTime">2013-06-08T14:58:56.591Z</ext1:time>
+						<ext1:boolean xsi:type="xsd:boolean">true</ext1:boolean>
+						<ext1:string xsi:type="xsd:string">string</ext1:string>
+						<ext1:object>
+							<ext2:string xsi:type="xsd:string">stringInObject</ext2:string>
+							<ext2:array xsi:type="xsd:integer">11</ext2:array>
+							<ext2:array xsi:type="xsd:double">21</ext2:array>
+							<ext2:array xsi:type="xsd:string">stringInArrayInObject</ext2:array>
+							<ext2:object>
+								<ext3:string xsi:type="xsd:string">stringInObjectInObject</ext3:string>
+							</ext2:object>
+						</ext1:object>
+						<ext1:array xsi:type="xsd:integer">12</ext1:array>
+						<ext1:array xsi:type="xsd:double">22</ext1:array>
+						<ext1:array xsi:type="xsd:dateTime">2013-06-08T14:58:56.591Z</ext1:array>
+						<ext1:array xsi:type="xsd:boolean">true</ext1:array>
+						<ext1:array xsi:type="xsd:string">stringInArray</ext1:array>
+						<ext1:array>
+							<ext1:object>
+								<ext2:int xsi:type="xsd:integer">13</ext2:int>
+								<ext2:string xsi:type="xsd:string">stringInObjectInArray</ext2:string>
+								<ext2:array xsi:type="xsd:integer">14</ext2:array>
+								<ext2:array xsi:type="xsd:double">23.0</ext2:array>
+								<ext2:array xsi:type="xsd:string">stringInArrayInObjectInArray</ext2:array>
+								<ext2:object>
+									<ext3:string xsi:type="xsd:string">stringInObjectInObjectInArray</ext3:string>
+								</ext2:object>
+							</ext1:object>
+						</ext1:array>
+					</sensorElement>
+				</sensorElementList>
+				<persistentDisposition>
+					<unset>urn:epcglobal:cbv:disp:completeness_inferred</unset>
+					<set>urn:epcglobal:cbv:disp:completeness_verified</set>
+				</persistentDisposition>
+				<ext1:default>stringAsDefaultValue</ext1:default>
+				<ext1:int xsi:type="xsd:integer">10</ext1:int>
+				<ext1:float xsi:type="xsd:double">20</ext1:float>
+				<ext1:time xsi:type="xsd:dateTime">2013-06-08T14:58:56.591Z</ext1:time>
+				<ext1:boolean xsi:type="xsd:boolean">true</ext1:boolean>
+				<ext1:string xsi:type="xsd:string">string</ext1:string>
+				<ext1:object>
+					<ext2:string xsi:type="xsd:string">stringInObject</ext2:string>
+					<ext2:array xsi:type="xsd:integer">11</ext2:array>
+					<ext2:array xsi:type="xsd:double">21</ext2:array>
+					<ext2:array xsi:type="xsd:string">stringInArrayInObject</ext2:array>
+					<ext2:object>
+						<ext3:string xsi:type="xsd:string">stringInObjectInObject</ext3:string>
+					</ext2:object>
+				</ext1:object>
+				<ext1:array xsi:type="xsd:integer">12</ext1:array>
+				<ext1:array xsi:type="xsd:double">22</ext1:array>
+				<ext1:array xsi:type="xsd:dateTime">2013-06-08T14:58:56.591Z</ext1:array>
+				<ext1:array xsi:type="xsd:boolean">true</ext1:array>
+				<ext1:array xsi:type="xsd:string">stringInArray</ext1:array>
+				<ext1:array>
+					<ext1:object>
+						<ext2:int xsi:type="xsd:integer">13</ext2:int>
+						<ext2:string xsi:type="xsd:string">stringInObjectInArray</ext2:string>
+						<ext2:array xsi:type="xsd:integer">14</ext2:array>
+						<ext2:array xsi:type="xsd:double">23.0</ext2:array>
+						<ext2:array xsi:type="xsd:string">stringInArrayInObjectInArray</ext2:array>
+						<ext2:object>
+							<ext3:string xsi:type="xsd:string">stringInObjectInObjectInArray</ext3:string>
+						</ext2:object>
+					</ext1:object>
+				</ext1:array>
+			</AssociationEvent>
+		</EventList>
+	</EPCISBody>
+</epcis:EPCISDocument>

--- a/XML/WithFullCombinationOfFields/masterdata_all_possible_fields.xml
+++ b/XML/WithFullCombinationOfFields/masterdata_all_possible_fields.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE project>
+<epcis:EPCISDocument schemaVersion="2.0"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:ext1="http://ext.com/ext1" xmlns:ext2="http://ext.com/ext2"
+	xmlns:ext3="http://ext.com/ext3"
+	creationDate="2013-06-04T14:59:02.099+02:00"
+	xmlns:epcis="urn:epcglobal:epcis:xsd:2">
+	<EPCISHeader>
+		<extension>
+			<EPCISMasterData>
+				<VocabularyList>
+					<Vocabulary
+						type="urn:epcglobal:epcis:vtype:BusinessLocation">
+						<VocabularyElementList>
+							<VocabularyElement
+								id="urn:epc:id:sgln:0037000.00729.0">
+								<attribute id="http://ext.com/ext1#string">stringValue</attribute>
+								<attribute id="http://ext.com/ext1#array">string1InArray</attribute>
+								<attribute id="http://ext.com/ext1#array">string2InArray</attribute>
+								<attribute id="http://ext.com/ext1#object1">
+									<ext1:object2>
+										<inner1 xsi:type="xsd:string">val1</inner1>
+										<inner2 xsi:type="xsd:string">val2</inner2>
+									</ext1:object2>
+									<ext1:string xsi:type="xsd:string">string</ext1:string>
+								</attribute>
+								<attribute id="http://ext.com/ext1#object2">
+									<ext1:default>stringAsDefaultValue</ext1:default>
+									<ext1:int xsi:type="xsd:integer">10</ext1:int>
+									<ext1:float xsi:type="xsd:double">20</ext1:float>
+									<ext1:time xsi:type="xsd:dateTime">2013-06-08T14:58:56.591Z</ext1:time>
+									<ext1:boolean xsi:type="xsd:boolean">true</ext1:boolean>
+									<ext1:string xsi:type="xsd:string">string</ext1:string>
+									<ext1:object>
+										<ext2:string xsi:type="xsd:string">stringInObject</ext2:string>
+										<ext2:array xsi:type="xsd:integer">11</ext2:array>
+										<ext2:array xsi:type="xsd:double">21</ext2:array>
+										<ext2:array xsi:type="xsd:string">stringInArrayInObject</ext2:array>
+										<ext2:object>
+											<ext3:string xsi:type="xsd:string">stringInObjectInObject</ext3:string>
+										</ext2:object>
+									</ext1:object>
+									<ext1:array xsi:type="xsd:integer">12</ext1:array>
+									<ext1:array xsi:type="xsd:double">22</ext1:array>
+									<ext1:array xsi:type="xsd:dateTime">2013-06-08T14:58:56.591Z</ext1:array>
+									<ext1:array xsi:type="xsd:boolean">true</ext1:array>
+									<ext1:array xsi:type="xsd:string">stringInArray</ext1:array>
+									<ext1:array>
+										<ext1:object>
+											<ext2:int xsi:type="xsd:integer">13</ext2:int>
+											<ext2:string xsi:type="xsd:string">stringInObjectInArray</ext2:string>
+											<ext2:array xsi:type="xsd:integer">14</ext2:array>
+											<ext2:array xsi:type="xsd:double">23.0</ext2:array>
+											<ext2:array xsi:type="xsd:string">stringInArrayInObjectInArray</ext2:array>
+											<ext2:object>
+												<ext3:string xsi:type="xsd:string">stringInObjectInObjectInArray</ext3:string>
+											</ext2:object>
+										</ext1:object>
+									</ext1:array>
+								</attribute>
+								<children>
+									<!-- for WD_bizLocation test -->
+									<id>urn:epc:id:sgln:0037000.00729.8201</id>
+								</children>
+							</VocabularyElement>
+						</VocabularyElementList>
+					</Vocabulary>
+					<Vocabulary type="urn:epcglobal:epcis:vtype:ReadPoint">
+						<VocabularyElementList>
+							<VocabularyElement
+								id="urn:epc:id:sgln:0037000.00729.0">
+								<attribute id="http://ext.com/ext1#string">stringValue</attribute>
+								<attribute id="http://ext.com/ext1#array">string1InArray</attribute>
+								<attribute id="http://ext.com/ext1#array">string2InArray</attribute>
+								<attribute id="http://ext.com/ext1#object1">
+									<ext1:object2>
+										<inner1 xsi:type="xsd:string">val1</inner1>
+										<inner2 xsi:type="xsd:string">val2</inner2>
+									</ext1:object2>
+									<ext1:string xsi:type="xsd:string">string</ext1:string>
+								</attribute>
+								<attribute id="http://ext.com/ext1#object2">
+									<ext1:default>stringAsDefaultValue</ext1:default>
+									<ext1:int xsi:type="xsd:integer">10</ext1:int>
+									<ext1:float xsi:type="xsd:double">20</ext1:float>
+									<ext1:time xsi:type="xsd:dateTime">2013-06-08T14:58:56.591Z</ext1:time>
+									<ext1:boolean xsi:type="xsd:boolean">true</ext1:boolean>
+									<ext1:string xsi:type="xsd:string">string</ext1:string>
+									<ext1:object>
+										<ext2:string xsi:type="xsd:string">stringInObject</ext2:string>
+										<ext2:array xsi:type="xsd:integer">11</ext2:array>
+										<ext2:array xsi:type="xsd:double">21</ext2:array>
+										<ext2:array xsi:type="xsd:string">stringInArrayInObject</ext2:array>
+										<ext2:object>
+											<ext3:string xsi:type="xsd:string">stringInObjectInObject</ext3:string>
+										</ext2:object>
+									</ext1:object>
+									<ext1:array xsi:type="xsd:integer">12</ext1:array>
+									<ext1:array xsi:type="xsd:double">22</ext1:array>
+									<ext1:array xsi:type="xsd:dateTime">2013-06-08T14:58:56.591Z</ext1:array>
+									<ext1:array xsi:type="xsd:boolean">true</ext1:array>
+									<ext1:array xsi:type="xsd:string">stringInArray</ext1:array>
+									<ext1:array>
+										<ext1:object>
+											<ext2:int xsi:type="xsd:integer">13</ext2:int>
+											<ext2:string xsi:type="xsd:string">stringInObjectInArray</ext2:string>
+											<ext2:array xsi:type="xsd:integer">14</ext2:array>
+											<ext2:array xsi:type="xsd:double">23.0</ext2:array>
+											<ext2:array xsi:type="xsd:string">stringInArrayInObjectInArray</ext2:array>
+											<ext2:object>
+												<ext3:string xsi:type="xsd:string">stringInObjectInObjectInArray</ext3:string>
+											</ext2:object>
+										</ext1:object>
+									</ext1:array>
+								</attribute>
+								<children>
+									<!-- for WD_bizLocation test -->
+									<id>urn:epc:id:sgln:0037000.00729.8201</id>
+								</children>
+							</VocabularyElement>
+						</VocabularyElementList>
+
+					</Vocabulary>
+				</VocabularyList>
+			</EPCISMasterData>
+		</extension>
+	</EPCISHeader>
+	<EPCISBody>
+		<EventList>
+		</EventList>
+	</EPCISBody>
+</epcis:EPCISDocument>

--- a/XML/WithFullCombinationOfFields/object_event_all_possible_fields.xml
+++ b/XML/WithFullCombinationOfFields/object_event_all_possible_fields.xml
@@ -1,0 +1,190 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!DOCTYPE project>
+<epcis:EPCISDocument schemaVersion="2.0"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:ext1="http://ext.com/ext1" xmlns:ext2="http://ext.com/ext2"
+	xmlns:ext3="http://ext.com/ext3" xmlns:cbvmda="urn:epcglobal:cbv:mda"
+	creationDate="2013-06-04T14:59:02.099+02:00"
+	xmlns:epcis="urn:epcglobal:epcis:xsd:2">
+	<EPCISBody>
+		<EventList>
+			<ObjectEvent>
+				<eventTime>2005-04-04T20:33:31.116-06:00</eventTime>
+				<eventTimeZoneOffset>-06:00</eventTimeZoneOffset>
+				<epcList>
+					<epc>urn:epc:id:sgtin:0614141.107346.2018</epc>
+				</epcList>
+				<action>OBSERVE</action>
+				<bizStep>urn:epcglobal:cbv:bizstep:receiving</bizStep>
+				<disposition>urn:epcglobal:cbv:disp:in_progress</disposition>
+				<readPoint>
+					<id>urn:epc:id:sgln:0012345.11111.400</id>
+				</readPoint>
+				<bizLocation>
+					<id>urn:epc:id:sgln:0012345.11111.0</id>
+				</bizLocation>
+				<bizTransactionList>
+					<bizTransaction type="urn:epcglobal:cbv:btt:po">urn:epc:id:gdti:0614141.00001.1618034</bizTransaction>
+					<bizTransaction
+						type="urn:epcglobal:cbv:btt:pedigree">urn:epc:id:gsrn:0614141.0000010253</bizTransaction>
+				</bizTransactionList>
+				<quantityList>
+					<quantityElement>
+						<epcClass>urn:epc:class:lgtin:4012345.012345.998877</epcClass>
+						<quantity>200</quantity>
+						<uom>KGM</uom>
+					</quantityElement>
+				</quantityList>
+				<sourceList>
+					<source type="urn:epcglobal:cbv:sdt:location">urn:epc:id:sgln:4012345.00225.0</source>
+					<source type="urn:epcglobal:cbv:sdt:possessing_party">urn:epc:id:pgln:4012345.00225</source>
+					<source type="urn:epcglobal:cbv:sdt:owning_party">urn:epc:id:pgln:4012345.00225</source>
+				</sourceList>
+				<destinationList>
+					<destination type="urn:epcglobal:cbv:sdt:location">urn:epc:id:sgln:0614141.00777.0</destination>
+					<destination
+						type="urn:epcglobal:cbv:sdt:possessing_party">urn:epc:id:pgln:0614141.00777</destination>
+					<destination type="urn:epcglobal:cbv:sdt:owning_party">urn:epc:id:pgln:0614141.00777</destination>
+				</destinationList>
+				<sensorElementList>
+					<sensorElement>
+						<sensorMetadata
+							time="2019-04-02T14:05:00.000+01:00"
+							deviceID="urn:epc:id:giai:4000001.111"
+							deviceMetadata="https://id.gs1.org/giai/4000001111"
+							rawData="https://example.org/giai/401234599999"
+							startTime="2019-04-02T13:55:01.000+01:00"
+							endTime="2019-04-02T14:55:00.000+01:00"
+							bizRules="https://example.com/gdti/4012345000054987"
+							dataProcessingMethod="https://example.com/gdti/4012345000054987"
+							ext1:someFurtherMetadata="someText" />
+						<sensorReport value="26.0" type="gs1:Temperature"
+							component="example:x" stringValue="SomeString"
+							booleanValue="true" hexBinaryValue="f0f0f0"
+							uriValue="https://id.gs1.org/giai/4000001111" uom="CEL"
+							minValue="26.0" maxValue="26.2" sDev="0.1"
+							chemicalSubstance="https://identifiers.org/inchikey:CZMRCDWAGMRECN-UGDNZRGBSA-N"
+							microorganism="https://www.ncbi.nlm.nih.gov/taxonomy/1126011"
+							deviceID="urn:epc:id:giai:4000001.111"
+							deviceMetadata="https://id.gs1.org/giai/4000001111"
+							rawData="https://example.org/giai/401234599999"
+							time="2019-07-19T14:00:00.000+01:00" meanValue="13.2"
+							percRank="50" percValue="12.7"
+							dataProcessingMethod="https://example.com/gdti/4012345000054987"
+							ext1:someFurtherReportData="someText" />
+						<ext1:default>stringAsDefaultValue</ext1:default>
+						<ext1:int xsi:type="xsd:integer">10</ext1:int>
+						<ext1:float xsi:type="xsd:double">20</ext1:float>
+						<ext1:time xsi:type="xsd:dateTime">2013-06-08T14:58:56.591Z</ext1:time>
+						<ext1:boolean xsi:type="xsd:boolean">true</ext1:boolean>
+						<ext1:string xsi:type="xsd:string">string</ext1:string>
+						<ext1:object>
+							<ext2:string xsi:type="xsd:string">stringInObject</ext2:string>
+							<ext2:array xsi:type="xsd:integer">11</ext2:array>
+							<ext2:array xsi:type="xsd:double">21</ext2:array>
+							<ext2:array xsi:type="xsd:string">stringInArrayInObject</ext2:array>
+							<ext2:object>
+								<ext3:string xsi:type="xsd:string">stringInObjectInObject</ext3:string>
+							</ext2:object>
+						</ext1:object>
+						<ext1:array xsi:type="xsd:integer">12</ext1:array>
+						<ext1:array xsi:type="xsd:double">22</ext1:array>
+						<ext1:array xsi:type="xsd:dateTime">2013-06-08T14:58:56.591Z</ext1:array>
+						<ext1:array xsi:type="xsd:boolean">true</ext1:array>
+						<ext1:array xsi:type="xsd:string">stringInArray</ext1:array>
+						<ext1:array>
+							<ext1:object>
+								<ext2:int xsi:type="xsd:integer">13</ext2:int>
+								<ext2:string xsi:type="xsd:string">stringInObjectInArray</ext2:string>
+								<ext2:array xsi:type="xsd:integer">14</ext2:array>
+								<ext2:array xsi:type="xsd:double">23.0</ext2:array>
+								<ext2:array xsi:type="xsd:string">stringInArrayInObjectInArray</ext2:array>
+								<ext2:object>
+									<ext3:string xsi:type="xsd:string">stringInObjectInObjectInArray</ext3:string>
+								</ext2:object>
+							</ext1:object>
+						</ext1:array>
+					</sensorElement>
+				</sensorElementList>
+				<persistentDisposition>
+					<unset>urn:epcglobal:cbv:disp:completeness_inferred</unset>
+					<set>urn:epcglobal:cbv:disp:completeness_verified</set>
+				</persistentDisposition>
+				<ilmd>
+					<cbvmda:countryOfOrigin>GB</cbvmda:countryOfOrigin>
+					<cbvmda:countryOfExport>KR</cbvmda:countryOfExport>
+					<cbvmda:drainedWeight
+						measurementUnitCode="KGM">3.5</cbvmda:drainedWeight>
+					<cbvmda:grossWeight measurementUnitCode="KGM">3.5</cbvmda:grossWeight>
+					<cbvmda:lotNumber>ABC123</cbvmda:lotNumber>
+					<cbvmda:netWeight measurementUnitCode="KGM">3.5</cbvmda:netWeight>
+					<ext1:default>stringAsDefaultValue</ext1:default>
+					<ext1:int xsi:type="xsd:integer">10</ext1:int>
+					<ext1:float xsi:type="xsd:double">20</ext1:float>
+					<ext1:time xsi:type="xsd:dateTime">2013-06-08T14:58:56.591Z</ext1:time>
+					<ext1:boolean xsi:type="xsd:boolean">true</ext1:boolean>
+					<ext1:string xsi:type="xsd:string">string</ext1:string>
+					<ext1:object>
+						<ext2:string xsi:type="xsd:string">stringInObject</ext2:string>
+						<ext2:array xsi:type="xsd:integer">11</ext2:array>
+						<ext2:array xsi:type="xsd:double">21</ext2:array>
+						<ext2:array xsi:type="xsd:string">stringInArrayInObject</ext2:array>
+						<ext2:object>
+							<ext3:string xsi:type="xsd:string">stringInObjectInObject</ext3:string>
+						</ext2:object>
+					</ext1:object>
+					<ext1:array xsi:type="xsd:integer">12</ext1:array>
+					<ext1:array xsi:type="xsd:double">22</ext1:array>
+					<ext1:array xsi:type="xsd:dateTime">2013-06-08T14:58:56.591Z</ext1:array>
+					<ext1:array xsi:type="xsd:boolean">true</ext1:array>
+					<ext1:array xsi:type="xsd:string">stringInArray</ext1:array>
+					<ext1:array>
+						<ext1:object>
+							<ext2:int xsi:type="xsd:integer">13</ext2:int>
+							<ext2:string xsi:type="xsd:string">stringInObjectInArray</ext2:string>
+							<ext2:array xsi:type="xsd:integer">14</ext2:array>
+							<ext2:array xsi:type="xsd:double">23.0</ext2:array>
+							<ext2:array xsi:type="xsd:string">stringInArrayInObjectInArray</ext2:array>
+							<ext2:object>
+								<ext3:string xsi:type="xsd:string">stringInObjectInObjectInArray</ext3:string>
+							</ext2:object>
+						</ext1:object>
+					</ext1:array>
+				</ilmd>
+				<ext1:default>stringAsDefaultValue</ext1:default>
+				<ext1:int xsi:type="xsd:integer">10</ext1:int>
+				<ext1:float xsi:type="xsd:double">20</ext1:float>
+				<ext1:time xsi:type="xsd:dateTime">2013-06-08T14:58:56.591Z</ext1:time>
+				<ext1:boolean xsi:type="xsd:boolean">true</ext1:boolean>
+				<ext1:string xsi:type="xsd:string">string</ext1:string>
+				<ext1:object>
+					<ext2:string xsi:type="xsd:string">stringInObject</ext2:string>
+					<ext2:array xsi:type="xsd:integer">11</ext2:array>
+					<ext2:array xsi:type="xsd:double">21</ext2:array>
+					<ext2:array xsi:type="xsd:string">stringInArrayInObject</ext2:array>
+					<ext2:object>
+						<ext3:string xsi:type="xsd:string">stringInObjectInObject</ext3:string>
+					</ext2:object>
+				</ext1:object>
+				<ext1:array xsi:type="xsd:integer">12</ext1:array>
+				<ext1:array xsi:type="xsd:double">22</ext1:array>
+				<ext1:array xsi:type="xsd:dateTime">2013-06-08T14:58:56.591Z</ext1:array>
+				<ext1:array xsi:type="xsd:boolean">true</ext1:array>
+				<ext1:array xsi:type="xsd:string">stringInArray</ext1:array>
+				<ext1:array>
+					<ext1:object>
+						<ext2:int xsi:type="xsd:integer">13</ext2:int>
+						<ext2:string xsi:type="xsd:string">stringInObjectInArray</ext2:string>
+						<ext2:array xsi:type="xsd:integer">14</ext2:array>
+						<ext2:array xsi:type="xsd:double">23.0</ext2:array>
+						<ext2:array xsi:type="xsd:string">stringInArrayInObjectInArray</ext2:array>
+						<ext2:object>
+							<ext3:string xsi:type="xsd:string">stringInObjectInObjectInArray</ext3:string>
+						</ext2:object>
+					</ext1:object>
+				</ext1:array>
+			</ObjectEvent>
+		</EventList>
+	</EPCISBody>
+</epcis:EPCISDocument>

--- a/XML/WithFullCombinationOfFields/transaction_event_all_possible_fields.xml
+++ b/XML/WithFullCombinationOfFields/transaction_event_all_possible_fields.xml
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!DOCTYPE project>
+<epcis:EPCISDocument schemaVersion="2.0"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:ext1="http://ext.com/ext1" xmlns:ext2="http://ext.com/ext2"
+	xmlns:ext3="http://ext.com/ext3"
+	creationDate="2013-06-04T14:59:02.099+02:00"
+	xmlns:epcis="urn:epcglobal:epcis:xsd:2">
+	<EPCISBody>
+		<EventList>
+			<TransactionEvent>
+				<eventTime>2005-04-03T20:33:31.116-06:00</eventTime>
+				<eventTimeZoneOffset>-06:00</eventTimeZoneOffset>
+				<bizTransactionList>
+					<bizTransaction type="urn:epcglobal:cbv:btt:po">urn:epc:id:gdti:0614141.00001.1618034</bizTransaction>
+					<bizTransaction
+						type="urn:epcglobal:cbv:btt:pedigree">urn:epc:id:gsrn:0614141.0000010253</bizTransaction>
+				</bizTransactionList>
+				<parentID>urn:epc:id:sscc:0614141.1234567890</parentID>
+				<epcList>
+					<epc>urn:epc:id:sgtin:0614141.107346.2017</epc>
+					<epc>urn:epc:id:sgtin:0614141.107346.2018</epc>
+				</epcList>
+				<action>ADD</action>
+				<bizStep>urn:epcglobal:cbv:bizstep:shipping</bizStep>
+				<disposition>urn:epcglobal:cbv:disp:in_transit</disposition>
+				<readPoint>
+					<id>urn:epc:id:sgln:0614141.07346.1234</id>
+				</readPoint>
+				<bizLocation>
+					<id>urn:epc:id:sgln:0614141.00888.0</id>
+				</bizLocation>
+				<quantityList>
+					<quantityElement>
+						<epcClass>urn:epc:class:lgtin:4012345.011111.4444</epcClass>
+						<quantity>10</quantity>
+						<uom>KGM</uom>
+					</quantityElement>
+				</quantityList>
+				<sourceList>
+					<source type="urn:epcglobal:cbv:sdt:location">urn:epc:id:sgln:4012345.00225.0</source>
+					<source type="urn:epcglobal:cbv:sdt:possessing_party">urn:epc:id:pgln:4012345.00225</source>
+					<source type="urn:epcglobal:cbv:sdt:owning_party">urn:epc:id:pgln:4012345.00225</source>
+				</sourceList>
+				<destinationList>
+					<destination type="urn:epcglobal:cbv:sdt:location">urn:epc:id:sgln:0614141.00777.0</destination>
+					<destination
+						type="urn:epcglobal:cbv:sdt:possessing_party">urn:epc:id:pgln:0614141.00777</destination>
+					<destination type="urn:epcglobal:cbv:sdt:owning_party">urn:epc:id:pgln:0614141.00777</destination>
+				</destinationList>
+				<sensorElementList>
+					<sensorElement>
+						<sensorMetadata
+							time="2019-04-02T14:05:00.000+01:00"
+							deviceID="urn:epc:id:giai:4000001.111"
+							deviceMetadata="https://id.gs1.org/giai/4000001111"
+							rawData="https://example.org/giai/401234599999"
+							startTime="2019-04-02T13:55:01.000+01:00"
+							endTime="2019-04-02T14:55:00.000+01:00"
+							bizRules="https://example.com/gdti/4012345000054987"
+							dataProcessingMethod="https://example.com/gdti/4012345000054987"
+							ext1:someFurtherMetadata="someText" />
+						<sensorReport value="26.0" type="gs1:Temperature"
+							component="example:x" stringValue="SomeString"
+							booleanValue="true" hexBinaryValue="f0f0f0"
+							uriValue="https://id.gs1.org/giai/4000001111" uom="CEL"
+							minValue="26.0" maxValue="26.2" sDev="0.1"
+							chemicalSubstance="https://identifiers.org/inchikey:CZMRCDWAGMRECN-UGDNZRGBSA-N"
+							microorganism="https://www.ncbi.nlm.nih.gov/taxonomy/1126011"
+							deviceID="urn:epc:id:giai:4000001.111"
+							deviceMetadata="https://id.gs1.org/giai/4000001111"
+							rawData="https://example.org/giai/401234599999"
+							time="2019-07-19T14:00:00.000+01:00" meanValue="13.2"
+							percRank="50" percValue="12.7"
+							dataProcessingMethod="https://example.com/gdti/4012345000054987"
+							ext1:someFurtherReportData="someText" />
+						<ext1:default>stringAsDefaultValue</ext1:default>
+						<ext1:int xsi:type="xsd:integer">10</ext1:int>
+						<ext1:float xsi:type="xsd:double">20</ext1:float>
+						<ext1:time xsi:type="xsd:dateTime">2013-06-08T14:58:56.591Z</ext1:time>
+						<ext1:boolean xsi:type="xsd:boolean">true</ext1:boolean>
+						<ext1:string xsi:type="xsd:string">string</ext1:string>
+						<ext1:object>
+							<ext2:string xsi:type="xsd:string">stringInObject</ext2:string>
+							<ext2:array xsi:type="xsd:integer">11</ext2:array>
+							<ext2:array xsi:type="xsd:double">21</ext2:array>
+							<ext2:array xsi:type="xsd:string">stringInArrayInObject</ext2:array>
+							<ext2:object>
+								<ext3:string xsi:type="xsd:string">stringInObjectInObject</ext3:string>
+							</ext2:object>
+						</ext1:object>
+						<ext1:array xsi:type="xsd:integer">12</ext1:array>
+						<ext1:array xsi:type="xsd:double">22</ext1:array>
+						<ext1:array xsi:type="xsd:dateTime">2013-06-08T14:58:56.591Z</ext1:array>
+						<ext1:array xsi:type="xsd:boolean">true</ext1:array>
+						<ext1:array xsi:type="xsd:string">stringInArray</ext1:array>
+						<ext1:array>
+							<ext1:object>
+								<ext2:int xsi:type="xsd:integer">13</ext2:int>
+								<ext2:string xsi:type="xsd:string">stringInObjectInArray</ext2:string>
+								<ext2:array xsi:type="xsd:integer">14</ext2:array>
+								<ext2:array xsi:type="xsd:double">23.0</ext2:array>
+								<ext2:array xsi:type="xsd:string">stringInArrayInObjectInArray</ext2:array>
+								<ext2:object>
+									<ext3:string xsi:type="xsd:string">stringInObjectInObjectInArray</ext3:string>
+								</ext2:object>
+							</ext1:object>
+						</ext1:array>
+					</sensorElement>
+				</sensorElementList>
+				<persistentDisposition>
+					<unset>urn:epcglobal:cbv:disp:completeness_inferred</unset>
+					<set>urn:epcglobal:cbv:disp:completeness_verified</set>
+				</persistentDisposition>
+				<ext1:default>stringAsDefaultValue</ext1:default>
+				<ext1:int xsi:type="xsd:integer">10</ext1:int>
+				<ext1:float xsi:type="xsd:double">20</ext1:float>
+				<ext1:time xsi:type="xsd:dateTime">2013-06-08T14:58:56.591Z</ext1:time>
+				<ext1:boolean xsi:type="xsd:boolean">true</ext1:boolean>
+				<ext1:string xsi:type="xsd:string">string</ext1:string>
+				<ext1:object>
+					<ext2:string xsi:type="xsd:string">stringInObject</ext2:string>
+					<ext2:array xsi:type="xsd:integer">11</ext2:array>
+					<ext2:array xsi:type="xsd:double">21</ext2:array>
+					<ext2:array xsi:type="xsd:string">stringInArrayInObject</ext2:array>
+					<ext2:object>
+						<ext3:string xsi:type="xsd:string">stringInObjectInObject</ext3:string>
+					</ext2:object>
+				</ext1:object>
+				<ext1:array xsi:type="xsd:integer">12</ext1:array>
+				<ext1:array xsi:type="xsd:double">22</ext1:array>
+				<ext1:array xsi:type="xsd:dateTime">2013-06-08T14:58:56.591Z</ext1:array>
+				<ext1:array xsi:type="xsd:boolean">true</ext1:array>
+				<ext1:array xsi:type="xsd:string">stringInArray</ext1:array>
+				<ext1:array>
+					<ext1:object>
+						<ext2:int xsi:type="xsd:integer">13</ext2:int>
+						<ext2:string xsi:type="xsd:string">stringInObjectInArray</ext2:string>
+						<ext2:array xsi:type="xsd:integer">14</ext2:array>
+						<ext2:array xsi:type="xsd:double">23.0</ext2:array>
+						<ext2:array xsi:type="xsd:string">stringInArrayInObjectInArray</ext2:array>
+						<ext2:object>
+							<ext3:string xsi:type="xsd:string">stringInObjectInObjectInArray</ext3:string>
+						</ext2:object>
+					</ext1:object>
+				</ext1:array>
+			</TransactionEvent>
+		</EventList>
+	</EPCISBody>
+</epcis:EPCISDocument>

--- a/XML/WithFullCombinationOfFields/transformation_event_all_possible_fields.xml
+++ b/XML/WithFullCombinationOfFields/transformation_event_all_possible_fields.xml
@@ -1,0 +1,228 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!DOCTYPE project>
+<epcis:EPCISDocument schemaVersion="2.0"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:ext1="http://ext.com/ext1" xmlns:ext2="http://ext.com/ext2"
+	xmlns:ext3="http://ext.com/ext3" xmlns:cbvmda="urn:epcglobal:cbv:mda"
+	creationDate="2013-06-04T14:59:02.099+02:00"
+	xmlns:epcis="urn:epcglobal:epcis:xsd:2">
+	<EPCISBody>
+		<EventList>
+			<TransformationEvent>
+				<eventTime>2013-10-31T14:58:56.591Z</eventTime>
+				<eventTimeZoneOffset>+02:00</eventTimeZoneOffset>
+				<inputEPCList>
+					<epc>urn:epc:id:sgtin:4012345.011122.25</epc>
+					<epc>urn:epc:id:sgtin:4000001.065432.99886655</epc>
+				</inputEPCList>
+				<inputQuantityList>
+					<quantityElement>
+						<epcClass>urn:epc:class:lgtin:4012345.011111.4444</epcClass>
+						<quantity>10</quantity>
+						<uom>KGM</uom>
+					</quantityElement>
+					<quantityElement>
+						<epcClass>urn:epc:class:lgtin:0614141.077777.987</epcClass>
+						<quantity>30</quantity>
+						<!-- As the uom field has been omitted, 30 instances (e.g., pieces) 
+							of GTIN '00614141777778' belonging to lot '987' have been used. -->
+					</quantityElement>
+					<quantityElement>
+						<epcClass>urn:epc:idpat:sgtin:4012345.066666.*</epcClass>
+						<quantity>220</quantity>
+						<!-- As the uom field has been omitted and as an EPC pattern is indicated, 
+							220 instances (e.g., pieces) of GTIN '04012345666663' have been used. -->
+					</quantityElement>
+				</inputQuantityList>
+				<outputEPCList>
+					<epc>urn:epc:id:sgtin:4012345.077889.25</epc>
+					<epc>urn:epc:id:sgtin:4012345.077889.26</epc>
+					<epc>urn:epc:id:sgtin:4012345.077889.27</epc>
+					<epc>urn:epc:id:sgtin:4012345.077889.28</epc>
+				</outputEPCList>
+				<outputQuantityList>
+					<quantityElement>
+						<epcClass>urn:epc:class:lgtin:4012345.011111.4444</epcClass>
+						<quantity>10</quantity>
+						<uom>KGM</uom>
+					</quantityElement>
+					<quantityElement>
+						<epcClass>urn:epc:class:lgtin:0614141.077777.987</epcClass>
+						<quantity>30</quantity>
+						<!-- As the uom field has been omitted, 30 instances (e.g., pieces) 
+							of GTIN '00614141777778' belonging to lot '987' have been used. -->
+					</quantityElement>
+					<quantityElement>
+						<epcClass>urn:epc:idpat:sgtin:4012345.066666.*</epcClass>
+						<quantity>220</quantity>
+						<!-- As the uom field has been omitted and as an EPC pattern is indicated, 
+							220 instances (e.g., pieces) of GTIN '04012345666663' have been used. -->
+					</quantityElement>
+				</outputQuantityList>
+				<transformationID>urn:epc:id:gdti:0614141.12345.400</transformationID>
+				<bizStep>urn:epcglobal:cbv:bizstep:commissioning</bizStep>
+				<disposition>urn:epcglobal:cbv:disp:in_progress</disposition>
+				<readPoint>
+					<id>urn:epc:id:sgln:4012345.00001.0</id>
+				</readPoint>
+				<bizLocation>
+					<id>urn:epc:id:sgln:0614141.00888.0</id>
+				</bizLocation>
+				<bizTransactionList>
+					<bizTransaction type="urn:epcglobal:cbv:btt:po">urn:epc:id:gdti:0614141.00001.1618034</bizTransaction>
+					<bizTransaction
+						type="urn:epcglobal:cbv:btt:pedigree">urn:epc:id:gsrn:0614141.0000010253</bizTransaction>
+				</bizTransactionList>
+				<sourceList>
+					<source type="urn:epcglobal:cbv:sdt:location">urn:epc:id:sgln:4012345.00225.0</source>
+					<source type="urn:epcglobal:cbv:sdt:possessing_party">urn:epc:id:pgln:4012345.00225</source>
+					<source type="urn:epcglobal:cbv:sdt:owning_party">urn:epc:id:pgln:4012345.00225</source>
+				</sourceList>
+				<destinationList>
+					<destination type="urn:epcglobal:cbv:sdt:location">urn:epc:id:sgln:0614141.00777.0</destination>
+					<destination
+						type="urn:epcglobal:cbv:sdt:possessing_party">urn:epc:id:pgln:0614141.00777</destination>
+					<destination type="urn:epcglobal:cbv:sdt:owning_party">urn:epc:id:pgln:0614141.00777</destination>
+				</destinationList>
+				<sensorElementList>
+					<sensorElement>
+						<sensorMetadata
+							time="2019-04-02T14:05:00.000+01:00"
+							deviceID="urn:epc:id:giai:4000001.111"
+							deviceMetadata="https://id.gs1.org/giai/4000001111"
+							rawData="https://example.org/giai/401234599999"
+							startTime="2019-04-02T13:55:01.000+01:00"
+							endTime="2019-04-02T14:55:00.000+01:00"
+							bizRules="https://example.com/gdti/4012345000054987"
+							dataProcessingMethod="https://example.com/gdti/4012345000054987"
+							ext1:someFurtherMetadata="someText" />
+						<sensorReport value="26.0" type="gs1:Temperature"
+							component="example:x" stringValue="SomeString"
+							booleanValue="true" hexBinaryValue="f0f0f0"
+							uriValue="https://id.gs1.org/giai/4000001111" uom="CEL"
+							minValue="26.0" maxValue="26.2" sDev="0.1"
+							chemicalSubstance="https://identifiers.org/inchikey:CZMRCDWAGMRECN-UGDNZRGBSA-N"
+							microorganism="https://www.ncbi.nlm.nih.gov/taxonomy/1126011"
+							deviceID="urn:epc:id:giai:4000001.111"
+							deviceMetadata="https://id.gs1.org/giai/4000001111"
+							rawData="https://example.org/giai/401234599999"
+							time="2019-07-19T14:00:00.000+01:00" meanValue="13.2"
+							percRank="50" percValue="12.7"
+							dataProcessingMethod="https://example.com/gdti/4012345000054987"
+							ext1:someFurtherReportData="someText" />
+						<ext1:default>stringAsDefaultValue</ext1:default>
+						<ext1:int xsi:type="xsd:integer">10</ext1:int>
+						<ext1:float xsi:type="xsd:double">20</ext1:float>
+						<ext1:time xsi:type="xsd:dateTime">2013-06-08T14:58:56.591Z</ext1:time>
+						<ext1:boolean xsi:type="xsd:boolean">true</ext1:boolean>
+						<ext1:string xsi:type="xsd:string">string</ext1:string>
+						<ext1:object>
+							<ext2:string xsi:type="xsd:string">stringInObject</ext2:string>
+							<ext2:array xsi:type="xsd:integer">11</ext2:array>
+							<ext2:array xsi:type="xsd:double">21</ext2:array>
+							<ext2:array xsi:type="xsd:string">stringInArrayInObject</ext2:array>
+							<ext2:object>
+								<ext3:string xsi:type="xsd:string">stringInObjectInObject</ext3:string>
+							</ext2:object>
+						</ext1:object>
+						<ext1:array xsi:type="xsd:integer">12</ext1:array>
+						<ext1:array xsi:type="xsd:double">22</ext1:array>
+						<ext1:array xsi:type="xsd:dateTime">2013-06-08T14:58:56.591Z</ext1:array>
+						<ext1:array xsi:type="xsd:boolean">true</ext1:array>
+						<ext1:array xsi:type="xsd:string">stringInArray</ext1:array>
+						<ext1:array>
+							<ext1:object>
+								<ext2:int xsi:type="xsd:integer">13</ext2:int>
+								<ext2:string xsi:type="xsd:string">stringInObjectInArray</ext2:string>
+								<ext2:array xsi:type="xsd:integer">14</ext2:array>
+								<ext2:array xsi:type="xsd:double">23.0</ext2:array>
+								<ext2:array xsi:type="xsd:string">stringInArrayInObjectInArray</ext2:array>
+								<ext2:object>
+									<ext3:string xsi:type="xsd:string">stringInObjectInObjectInArray</ext3:string>
+								</ext2:object>
+							</ext1:object>
+						</ext1:array>
+					</sensorElement>
+				</sensorElementList>
+				<persistentDisposition>
+					<unset>urn:epcglobal:cbv:disp:completeness_inferred</unset>
+					<set>urn:epcglobal:cbv:disp:completeness_verified</set>
+				</persistentDisposition>
+				<ilmd>
+					<cbvmda:countryOfOrigin>GB</cbvmda:countryOfOrigin>
+					<cbvmda:countryOfExport>KR</cbvmda:countryOfExport>
+					<cbvmda:drainedWeight
+						measurementUnitCode="KGM">3.5</cbvmda:drainedWeight>
+					<cbvmda:grossWeight measurementUnitCode="KGM">3.5</cbvmda:grossWeight>
+					<cbvmda:lotNumber>ABC123</cbvmda:lotNumber>
+					<cbvmda:netWeight measurementUnitCode="KGM">3.5</cbvmda:netWeight>
+					<ext1:default>stringAsDefaultValue</ext1:default>
+					<ext1:int xsi:type="xsd:integer">10</ext1:int>
+					<ext1:float xsi:type="xsd:double">20</ext1:float>
+					<ext1:time xsi:type="xsd:dateTime">2013-06-08T14:58:56.591Z</ext1:time>
+					<ext1:boolean xsi:type="xsd:boolean">true</ext1:boolean>
+					<ext1:string xsi:type="xsd:string">string</ext1:string>
+					<ext1:object>
+						<ext2:string xsi:type="xsd:string">stringInObject</ext2:string>
+						<ext2:array xsi:type="xsd:integer">11</ext2:array>
+						<ext2:array xsi:type="xsd:double">21</ext2:array>
+						<ext2:array xsi:type="xsd:string">stringInArrayInObject</ext2:array>
+						<ext2:object>
+							<ext3:string xsi:type="xsd:string">stringInObjectInObject</ext3:string>
+						</ext2:object>
+					</ext1:object>
+					<ext1:array xsi:type="xsd:integer">12</ext1:array>
+					<ext1:array xsi:type="xsd:double">22</ext1:array>
+					<ext1:array xsi:type="xsd:dateTime">2013-06-08T14:58:56.591Z</ext1:array>
+					<ext1:array xsi:type="xsd:boolean">true</ext1:array>
+					<ext1:array xsi:type="xsd:string">stringInArray</ext1:array>
+					<ext1:array>
+						<ext1:object>
+							<ext2:int xsi:type="xsd:integer">13</ext2:int>
+							<ext2:string xsi:type="xsd:string">stringInObjectInArray</ext2:string>
+							<ext2:array xsi:type="xsd:integer">14</ext2:array>
+							<ext2:array xsi:type="xsd:double">23.0</ext2:array>
+							<ext2:array xsi:type="xsd:string">stringInArrayInObjectInArray</ext2:array>
+							<ext2:object>
+								<ext3:string xsi:type="xsd:string">stringInObjectInObjectInArray</ext3:string>
+							</ext2:object>
+						</ext1:object>
+					</ext1:array>
+				</ilmd>
+				<ext1:default>stringAsDefaultValue</ext1:default>
+				<ext1:int xsi:type="xsd:integer">10</ext1:int>
+				<ext1:float xsi:type="xsd:double">20</ext1:float>
+				<ext1:time xsi:type="xsd:dateTime">2013-06-08T14:58:56.591Z</ext1:time>
+				<ext1:boolean xsi:type="xsd:boolean">true</ext1:boolean>
+				<ext1:string xsi:type="xsd:string">string</ext1:string>
+				<ext1:object>
+					<ext2:string xsi:type="xsd:string">stringInObject</ext2:string>
+					<ext2:array xsi:type="xsd:integer">11</ext2:array>
+					<ext2:array xsi:type="xsd:double">21</ext2:array>
+					<ext2:array xsi:type="xsd:string">stringInArrayInObject</ext2:array>
+					<ext2:object>
+						<ext3:string xsi:type="xsd:string">stringInObjectInObject</ext3:string>
+					</ext2:object>
+				</ext1:object>
+				<ext1:array xsi:type="xsd:integer">12</ext1:array>
+				<ext1:array xsi:type="xsd:double">22</ext1:array>
+				<ext1:array xsi:type="xsd:dateTime">2013-06-08T14:58:56.591Z</ext1:array>
+				<ext1:array xsi:type="xsd:boolean">true</ext1:array>
+				<ext1:array xsi:type="xsd:string">stringInArray</ext1:array>
+				<ext1:array>
+					<ext1:object>
+						<ext2:int xsi:type="xsd:integer">13</ext2:int>
+						<ext2:string xsi:type="xsd:string">stringInObjectInArray</ext2:string>
+						<ext2:array xsi:type="xsd:integer">14</ext2:array>
+						<ext2:array xsi:type="xsd:double">23.0</ext2:array>
+						<ext2:array xsi:type="xsd:string">stringInArrayInObjectInArray</ext2:array>
+						<ext2:object>
+							<ext3:string xsi:type="xsd:string">stringInObjectInObjectInArray</ext3:string>
+						</ext2:object>
+					</ext1:object>
+				</ext1:array>
+			</TransformationEvent>
+		</EventList>
+	</EPCISBody>
+</epcis:EPCISDocument>

--- a/XSD/EPCglobal-epcis-2_0.xsd
+++ b/XSD/EPCglobal-epcis-2_0.xsd
@@ -52,7 +52,6 @@ GS1 retains the right to make changes to this document at any time, without noti
     <xsd:sequence>
       <xsd:element ref="sbdh:StandardBusinessDocumentHeader" minOccurs="0"/>
       <xsd:element name="extension" type="epcis:EPCISHeaderExtensionType" minOccurs="0"/>
-      <xsd:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
     </xsd:sequence>
     <xsd:anyAttribute processContents="lax"/>
   </xsd:complexType>


### PR DESCRIPTION
In applying the latest update of XSD at Jun 23rd, we found a XSD problem called Unique Particle Attribution,
because the latest update tried to allow ignoring SBDH for Masterdata capturing. 
I believe that the community has a consensus of the necessity of the convenience of the optional field;
so thus I suggest one way to resolve this issue. The fixed schema is already tested in Oliot EPCIS X prototype.

We would like to share 7 EPCISDocuments in both XML and JSON format that semantically identical and thus should generate identical hash IDs.

We also would like to share the examples for all the event types and master data that have all the (technically) available fields as much as possible. XSD fix, Hash event ID examples, Full combination examples are valid for v2.0 schema and tested in our prototype.
