### PR TITLE
Disallow standard CBV URI prefixes in fields expecting bare word values

### DIFF
--- a/EPCIS-JSON-Schema.json
+++ b/EPCIS-JSON-Schema.json
@@ -942,7 +942,7 @@
     "disposition": {
       "anyOf": [
         {
-          "$ref": "#/definitions/vocab-uri"
+          "$ref": "#/definitions/vocab-other-uri"
         },
         {
           "type": "string",
@@ -1014,6 +1014,16 @@
       "type": "string",
       "format": "uri"
     },
+    "vocab-other-uri": {
+      "type": "string",
+      "format": "uri",
+      "pattern": "^(?!(urn:epcglobal:cbv|https?:\\/\\/ns\\.gs1\\.org/cbv\\/))"
+    },
+    "vocab-nonGS1WebVoc-uri": {
+      "type": "string",
+      "format": "uri",
+      "pattern": "^(?!(https?:\\/\\/gs1\\.org\\/voc\\/|https?:\\/\\/www\\.gs1\\.org\\/voc\\/))"
+    },
     "required-ld-context": {
       "type": "object",
       "required": [
@@ -1031,7 +1041,7 @@
     "error-reason": {
       "anyOf": [
         {
-          "$ref": "#/definitions/vocab-uri"
+          "$ref": "#/definitions/vocab-other-uri"
         },
         {
           "type": "string",
@@ -1045,7 +1055,7 @@
     "bizTransaction-type": {
       "anyOf": [
         {
-          "$ref": "#/definitions/vocab-uri"
+          "$ref": "#/definitions/vocab-other-uri"
         },
         {
           "type": "string",
@@ -1070,7 +1080,7 @@
     "source-dest-type": {
       "anyOf": [
         {
-          "$ref": "#/definitions/vocab-uri"
+          "$ref": "#/definitions/vocab-other-uri"
         },
         {
           "type": "string",
@@ -1085,7 +1095,7 @@
     "measurementType": {
       "anyOf": [
         {
-          "$ref": "#/definitions/vocab-uri"
+          "$ref": "#/definitions/vocab-nonGS1WebVoc-uri"
         },
         {
           "type": "string",
@@ -1169,7 +1179,7 @@
     "sensorAlertType": {
       "anyOf": [
         {
-          "$ref": "#/definitions/vocab-uri"
+          "$ref": "#/definitions/vocab-nonGS1WebVoc-uri"
         },
         {
           "type": "string",
@@ -1183,7 +1193,7 @@
     "component": {
       "anyOf": [
         {
-          "$ref": "#/definitions/vocab-uri"
+          "$ref": "#/definitions/vocab-other-uri"
         },
         {
           "type": "string",
@@ -1516,7 +1526,7 @@
     "bizStep": {
       "anyOf": [
         {
-          "$ref": "#/definitions/vocab-uri"
+          "$ref": "#/definitions/vocab-other-uri"
         },
         {
           "type": "string",

--- a/JSON-Schema/schemas/bizStep-JSON-Schema.json
+++ b/JSON-Schema/schemas/bizStep-JSON-Schema.json
@@ -5,7 +5,7 @@
         "bizStep": {
             "anyOf": [
                 {
-                    "$ref": "definitions-JSON-Schema.json#/definitions/vocab-uri"
+                    "$ref": "definitions-JSON-Schema.json#/definitions/vocab-other-uri"
                 },
                 {
                     "type": "string",

--- a/JSON-Schema/schemas/bizTransaction-type-JSON-Schema.json
+++ b/JSON-Schema/schemas/bizTransaction-type-JSON-Schema.json
@@ -5,7 +5,7 @@
         "bizTransaction-type": {
             "anyOf": [
                 {
-                    "$ref": "definitions-JSON-Schema.json#/definitions/vocab-uri"
+                    "$ref": "definitions-JSON-Schema.json#/definitions/vocab-other-uri"
                 },
                 {
                     "type": "string",

--- a/JSON-Schema/schemas/component-JSON-Schema.json
+++ b/JSON-Schema/schemas/component-JSON-Schema.json
@@ -5,7 +5,7 @@
         "component": {
             "anyOf": [
                 {
-                    "$ref": "definitions-JSON-Schema.json#/definitions/vocab-uri"
+                    "$ref": "definitions-JSON-Schema.json#/definitions/vocab-other-uri"
                 },
                 {
                     "type": "string",

--- a/JSON-Schema/schemas/definitions-JSON-Schema.json
+++ b/JSON-Schema/schemas/definitions-JSON-Schema.json
@@ -32,6 +32,16 @@
                     "type": "string",
                     "format": "uri"
         },
+        "vocab-other-uri": {
+                    "type": "string",
+                    "format": "uri",
+                    "pattern": "^(?!(urn:epcglobal:cbv|https?:\\/\\/ns\\.gs1\\.org\/cbv\\/))"
+        },
+        "vocab-nonGS1WebVoc-uri": {
+                    "type": "string",
+                    "format": "uri",
+                    "pattern": "^(?!(https?:\\/\\/gs1\\.org\\/voc\\/|https?:\\/\\/www\\.gs1\\.org\\/voc\\/))"
+        },
         "required-ld-context": {
             "type": "object",
             "required": ["@context"]

--- a/JSON-Schema/schemas/disposition-JSON-Schema.json
+++ b/JSON-Schema/schemas/disposition-JSON-Schema.json
@@ -5,7 +5,7 @@
         "disposition": {
             "anyOf": [
                 {
-                    "$ref": "definitions-JSON-Schema.json#/definitions/vocab-uri"
+                    "$ref": "definitions-JSON-Schema.json#/definitions/vocab-other-uri"
                 },
                 {
                     "type": "string",

--- a/JSON-Schema/schemas/error-reason-JSON-Schema.json
+++ b/JSON-Schema/schemas/error-reason-JSON-Schema.json
@@ -5,7 +5,7 @@
         "error-reason": {
             "anyOf": [
                 {
-                    "$ref": "definitions-JSON-Schema.json#/definitions/vocab-uri"
+                    "$ref": "definitions-JSON-Schema.json#/definitions/vocab-other-uri"
                 },
                 {
                     "type": "string",

--- a/JSON-Schema/schemas/measurement-type-JSON-Schema.json
+++ b/JSON-Schema/schemas/measurement-type-JSON-Schema.json
@@ -5,7 +5,7 @@
         "measurementType": {
             "anyOf": [
                 {
-                    "$ref": "definitions-JSON-Schema.json#/definitions/vocab-uri"
+                    "$ref": "definitions-JSON-Schema.json#/definitions/vocab-nonGS1WebVoc-uri"
                 },
                 {
                     "type": "string",

--- a/JSON-Schema/schemas/sensor-alert-type-JSON-Schema.json
+++ b/JSON-Schema/schemas/sensor-alert-type-JSON-Schema.json
@@ -5,7 +5,7 @@
         "sensorAlertType": {
             "anyOf": [
                 {
-                    "$ref": "definitions-JSON-Schema.json#/definitions/vocab-uri"
+                    "$ref": "definitions-JSON-Schema.json#/definitions/vocab-nonGS1WebVoc-uri"
                 },
                 {
                     "type": "string",

--- a/JSON-Schema/schemas/source-dest-type-JSON-Schema.json
+++ b/JSON-Schema/schemas/source-dest-type-JSON-Schema.json
@@ -5,7 +5,7 @@
         "source-dest-type": {
             "anyOf": [
                 {
-                    "$ref": "definitions-JSON-Schema.json#/definitions/vocab-uri"
+                    "$ref": "definitions-JSON-Schema.json#/definitions/vocab-other-uri"
                 },
                 {
                     "type": "string",


### PR DESCRIPTION
Updated JSON Schema to prevent use of urn:epcglobal:cbv: or https://ns.gs1.org/cbv/ in values for bizStep, bizTransaction-type, component, disposition, error-reason, source-dest-type
nor use of https://gs1.org/voc/ or https://www.gs1.org/voc/ in values for measurement-type or sensor-alert-type
Restriction implemented by defining new types, vocab-other-uri and vocab-nonGS1WebVoc-uri using regular expression patterns with negative lookahead (?! ...) - appears to work as intended when tested using https://www.jsonschemavalidator.net/