### PR TITLE
context-modifications branch

### DIFF
--- a/JSON-LD-Context/cbv-context-bizstep.jsonld
+++ b/JSON-LD-Context/cbv-context-bizstep.jsonld
@@ -1,9 +1,5 @@
 {
     "@context": {
-        "@protected": true,
-        "@version": 1.1,
-        "cbv": "https://ref.gs1.org/cbv/",
-
         "accepting": "cbv:BizStep-accepting",
         "arriving": "cbv:BizStep-arriving",
         "assembling": "cbv:BizStep-assembling",

--- a/JSON-LD-Context/cbv-context-biztransaction-type.jsonld
+++ b/JSON-LD-Context/cbv-context-biztransaction-type.jsonld
@@ -1,9 +1,5 @@
 {
     "@context": {
-        "@protected": true,
-        "@version": 1.1,
-        "cbv": "https://ref.gs1.org/cbv/",
-
         "bol": "cbv:BTT-bol",	        
         "cert": "cbv:BTT-cert",	        
         "desadv": "cbv:BTT-desadv",

--- a/JSON-LD-Context/cbv-context-component.jsonld
+++ b/JSON-LD-Context/cbv-context-component.jsonld
@@ -1,9 +1,5 @@
 {
     "@context": {
-        "@protected": true,
-        "@version": 1.1,
-        "cbv": "https://ref.gs1.org/cbv/",
-       
         "x": "cbv:Comp-x",
         "y": "cbv:Comp-y",
         "z": "cbv:Comp-z",

--- a/JSON-LD-Context/cbv-context-disposition.jsonld
+++ b/JSON-LD-Context/cbv-context-disposition.jsonld
@@ -1,9 +1,5 @@
 {
     "@context": {
-        "@protected": true,
-        "@version": 1.1,
-        "cbv": "https://ref.gs1.org/cbv/",
-       
         "active": "cbv:Disp-active",
         "available": "cbv:Disp-available",
         "completeness_verified": "cbv:Disp-completeness_verified",

--- a/JSON-LD-Context/cbv-context-error-reason.jsonld
+++ b/JSON-LD-Context/cbv-context-error-reason.jsonld
@@ -1,9 +1,5 @@
 {
     "@context": {
-        "@protected": true,
-        "@version": 1.1,
-        "cbv": "https://ref.gs1.org/cbv/",
-        
         "did_not_occur":  "cbv:ER-did_not_occur",
         "incorrect_data": "cbv:ER-incorrect_data"
     }

--- a/JSON-LD-Context/cbv-context-sourcedest-type.jsonld
+++ b/JSON-LD-Context/cbv-context-sourcedest-type.jsonld
@@ -1,9 +1,5 @@
 {
     "@context": {
-        "@protected": true,
-        "@version": 1.1,
-        "cbv": "https://ref.gs1.org/cbv/",
-
         "owning_party": "cbv:SDT-owning_party",
         "possessing_party": "cbv:SDT-possessing_party",
         "location": "cbv:SDT-location"

--- a/JSON-LD-Context/epcis-context-root.jsonld
+++ b/JSON-LD-Context/epcis-context-root.jsonld
@@ -3,7 +3,9 @@
         "@protected": true,
         "@version": 1.1,
         "epcis": "https://ref.gs1.org/epcis/",
+        "cbv": "https://ref.gs1.org/cbv/",
         "gs1": "https://gs1.org/voc/",
+        "cbvmda": "urn:epcglobal:cbv:mda:",
         "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
         "owl": "http://www.w3.org/2002/07/owl#",
         "xsd": "http://www.w3.org/2001/XMLSchema#",
@@ -68,8 +70,6 @@
             "@id": "epcis:sourceList",
             "@container": "@set",
             "@context": {
-                "@protected": true,
-                "epcis": "https://ref.gs1.org/epcis/",
                 "source": {
                     "@id": "epcis:sourceOrDestination",
                     "@type": "@id"
@@ -85,8 +85,6 @@
             "@id": "epcis:destinationList",
             "@container": "@set",
             "@context": {
-                "@protected": true,
-                "epcis": "https://ref.gs1.org/epcis/",
                 "destination": {
                     "@id": "epcis:sourceOrDestination",
                     "@type": "@id"
@@ -104,8 +102,6 @@
             "@context": [
                 "https://gs1.github.io/EPCIS/cbv-context-disposition.jsonld",
                 {
-                    "@protected": true,
-                    "epcis": "https://ref.gs1.org/epcis/",
                     "set": {
                         "@id": "epcis:set",
                         "@type": "@vocab",
@@ -137,12 +133,7 @@
             "@id": "epcis:bizTransactionList",
             "@container": "@set",
             "@context": {
-                "@protected": true,
-                "epcis": "https://ref.gs1.org/epcis/",
-                "bizTransaction": {
-                    "@id": "@id",
-                    "@type": "@id"
-                },
+                "bizTransaction": "@id",
                 "type": {
                     "@id": "epcis:bizTransactionType",
                     "@type": "@vocab",
@@ -185,8 +176,6 @@
             "@id": "epcis:sensorElementList",
             "@container": "@set",
             "@context": {
-                "@protected": true,
-                "epcis": "https://ref.gs1.org/epcis/",
                 "deviceID": {
                     "@id": "epcis:deviceID",
                     "@type": "@id"
@@ -211,8 +200,6 @@
                "sensorMetadata": {
                     "@id": "epcis:sensorMetadata",
                     "@context": {
-                        "@protected": true,
-                        "epcis": "https://ref.gs1.org/epcis/",
                         "startTime": {
                             "@id": "epcis:startTime",
                             "@type": "xsd:dateTimeStamp"
@@ -230,8 +217,6 @@
                 "sensorReport": {
                     "@id": "epcis:sensorReport",
                     "@context": {
-                            "@protected": true,
-                            "epcis": "https://ref.gs1.org/epcis/",
                             "type": {
                                 "@context": "https://gs1.github.io/EPCIS/gs1-context-measurement-type.jsonld",
                                 "@id": "epcis:measurementType",
@@ -311,8 +296,6 @@
         "errorDeclaration": {
             "@id": "epcis:errorDeclaration",
             "@context": {
-                "@protected": true,
-                "epcis": "https://ref.gs1.org/epcis/",
                 "reason": {
                     "@id": "epcis:reason",
                     "@type": "@vocab",

--- a/JSON-LD-Context/gs1-context-measurement-type.jsonld
+++ b/JSON-LD-Context/gs1-context-measurement-type.jsonld
@@ -1,8 +1,5 @@
 {
     "@context": {
-        "@protected": true,
-        "@version": 1.1,
-        "gs1": "https://gs1.org/voc/",
         "AbsoluteHumidity": "gs1:AbsoluteHumidity",
         "AbsorbedDose": "gs1:AbsorbedDose",
         "AbsorbedDoseRate": "gs1:AbsorbedDoseRate",

--- a/JSON-LD-Context/gs1-context-sensor-alert-type.jsonld
+++ b/JSON-LD-Context/gs1-context-sensor-alert-type.jsonld
@@ -1,8 +1,5 @@
 {
     "@context": {
-        "@protected": true,
-        "@version": 1.1,
-        "gs1": "https://gs1.org/voc/",
         "ALARM_CONDITION": "gs1:ALARM_CONDITION",
         "ERROR_CONDITION": "gs1:ERROR_CONDITION"
     }

--- a/epcis-context.jsonld
+++ b/epcis-context.jsonld
@@ -3,7 +3,9 @@
     "@protected": true,
     "@version": 1.1,
     "epcis": "https://ref.gs1.org/epcis/",
+    "cbv": "https://ref.gs1.org/cbv/",
     "gs1": "https://gs1.org/voc/",
+    "cbvmda": "urn:epcglobal:cbv:mda:",
     "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
     "owl": "http://www.w3.org/2002/07/owl#",
     "xsd": "http://www.w3.org/2001/XMLSchema#",
@@ -39,9 +41,6 @@
     },
     "bizStep": {
       "@context": {
-        "@protected": true,
-        "@version": 1.1,
-        "cbv": "https://ref.gs1.org/cbv/",
         "accepting": "cbv:BizStep-accepting",
         "arriving": "cbv:BizStep-arriving",
         "assembling": "cbv:BizStep-assembling",
@@ -89,9 +88,6 @@
     },
     "disposition": {
       "@context": {
-        "@protected": true,
-        "@version": 1.1,
-        "cbv": "https://ref.gs1.org/cbv/",
         "active": "cbv:Disp-active",
         "available": "cbv:Disp-available",
         "completeness_verified": "cbv:Disp-completeness_verified",
@@ -150,8 +146,6 @@
       "@id": "epcis:sourceList",
       "@container": "@set",
       "@context": {
-        "@protected": true,
-        "epcis": "https://ref.gs1.org/epcis/",
         "source": {
           "@id": "epcis:sourceOrDestination",
           "@type": "@id"
@@ -160,9 +154,6 @@
           "@id": "epcis:sourceOrDestinationType",
           "@type": "@vocab",
           "@context": {
-            "@protected": true,
-            "@version": 1.1,
-            "cbv": "https://ref.gs1.org/cbv/",
             "owning_party": "cbv:SDT-owning_party",
             "possessing_party": "cbv:SDT-possessing_party",
             "location": "cbv:SDT-location"
@@ -174,8 +165,6 @@
       "@id": "epcis:destinationList",
       "@container": "@set",
       "@context": {
-        "@protected": true,
-        "epcis": "https://ref.gs1.org/epcis/",
         "destination": {
           "@id": "epcis:sourceOrDestination",
           "@type": "@id"
@@ -184,9 +173,6 @@
           "@id": "epcis:sourceOrDestinationType",
           "@type": "@vocab",
           "@context": {
-            "@protected": true,
-            "@version": 1.1,
-            "cbv": "https://ref.gs1.org/cbv/",
             "owning_party": "cbv:SDT-owning_party",
             "possessing_party": "cbv:SDT-possessing_party",
             "location": "cbv:SDT-location"
@@ -199,9 +185,6 @@
       "@container": "@set",
       "@context": [
         {
-          "@protected": true,
-          "@version": 1.1,
-          "cbv": "https://ref.gs1.org/cbv/",
           "active": "cbv:Disp-active",
           "available": "cbv:Disp-available",
           "completeness_verified": "cbv:Disp-completeness_verified",
@@ -237,8 +220,6 @@
           "unknown": "cbv:Disp-unknown"
         },
         {
-          "@protected": true,
-          "epcis": "https://ref.gs1.org/epcis/",
           "set": {
             "@id": "epcis:set",
             "@type": "@vocab",
@@ -269,19 +250,11 @@
       "@id": "epcis:bizTransactionList",
       "@container": "@set",
       "@context": {
-        "@protected": true,
-        "epcis": "https://ref.gs1.org/epcis/",
-        "bizTransaction": {
-          "@id": "@id",
-          "@type": "@id"
-        },
+        "bizTransaction": "@id",
         "type": {
           "@id": "epcis:bizTransactionType",
           "@type": "@vocab",
           "@context": {
-            "@protected": true,
-            "@version": 1.1,
-            "cbv": "https://ref.gs1.org/cbv/",
             "bol": "cbv:BTT-bol",
             "cert": "cbv:BTT-cert",
             "desadv": "cbv:BTT-desadv",
@@ -334,8 +307,6 @@
       "@id": "epcis:sensorElementList",
       "@container": "@set",
       "@context": {
-        "@protected": true,
-        "epcis": "https://ref.gs1.org/epcis/",
         "deviceID": {
           "@id": "epcis:deviceID",
           "@type": "@id"
@@ -360,8 +331,6 @@
         "sensorMetadata": {
           "@id": "epcis:sensorMetadata",
           "@context": {
-            "@protected": true,
-            "epcis": "https://ref.gs1.org/epcis/",
             "startTime": {
               "@id": "epcis:startTime",
               "@type": "xsd:dateTimeStamp"
@@ -379,13 +348,8 @@
         "sensorReport": {
           "@id": "epcis:sensorReport",
           "@context": {
-            "@protected": true,
-            "epcis": "https://ref.gs1.org/epcis/",
             "type": {
               "@context": {
-                "@protected": true,
-                "@version": 1.1,
-                "gs1": "https://gs1.org/voc/",
                 "AbsoluteHumidity": "gs1:AbsoluteHumidity",
                 "AbsorbedDose": "gs1:AbsorbedDose",
                 "AbsorbedDoseRate": "gs1:AbsorbedDoseRate",
@@ -464,9 +428,6 @@
             },
             "exception": {
               "@context": {
-                "@protected": true,
-                "@version": 1.1,
-                "gs1": "https://gs1.org/voc/",
                 "ALARM_CONDITION": "gs1:ALARM_CONDITION",
                 "ERROR_CONDITION": "gs1:ERROR_CONDITION"
               },
@@ -495,9 +456,6 @@
             },
             "component": {
               "@context": {
-                "@protected": true,
-                "@version": 1.1,
-                "cbv": "https://ref.gs1.org/cbv/",
                 "x": "cbv:Comp-x",
                 "y": "cbv:Comp-y",
                 "z": "cbv:Comp-z",
@@ -560,15 +518,10 @@
     "errorDeclaration": {
       "@id": "epcis:errorDeclaration",
       "@context": {
-        "@protected": true,
-        "epcis": "https://ref.gs1.org/epcis/",
         "reason": {
           "@id": "epcis:reason",
           "@type": "@vocab",
           "@context": {
-            "@protected": true,
-            "@version": 1.1,
-            "cbv": "https://ref.gs1.org/cbv/",
             "did_not_occur": "cbv:ER-did_not_occur",
             "incorrect_data": "cbv:ER-incorrect_data"
           }


### PR DESCRIPTION
Removes repeated namespace declarations for cbv, epcis and gs1, as well as removing apparently redundant repeated declarations of "@protected": true and "@version": 1.1, as well as fixing a couple of other issues

