### PR TITLE
remove bizRules from SensorReport - for review only, do not merge yet

### DIFF
--- a/EPCIS-JSON-Schema.json
+++ b/EPCIS-JSON-Schema.json
@@ -807,9 +807,6 @@
         "dataProcessingMethod": {
           "$ref": "#/definitions/uri"
         },
-        "bizRules": {
-          "$ref": "#/definitions/uri"
-        },
         "time": {
           "$ref": "#/definitions/time"
         },
@@ -879,7 +876,6 @@
               "deviceMetadata",
               "rawData",
               "dataProcessingMethod",
-              "bizRules",
               "time",
               "microorganism",
               "chemicalSubstance",

--- a/JSON-Schema/schemas/event-definitions-JSON-Schema.json
+++ b/JSON-Schema/schemas/event-definitions-JSON-Schema.json
@@ -302,9 +302,6 @@
                 "dataProcessingMethod": {
                     "$ref": "#/definitions/uri"
                 },
-                "bizRules": {
-                    "$ref": "#/definitions/uri"
-                },
                 "time": {
                     "$ref": "#/definitions/time"
                 },
@@ -374,7 +371,6 @@
                             "deviceMetadata",
                             "rawData",
                             "dataProcessingMethod",
-                            "bizRules",
                             "time",
                             "microorganism",
                             "chemicalSubstance",

--- a/REST Bindings/openapi.json
+++ b/REST Bindings/openapi.json
@@ -7176,6 +7176,24 @@
           "DELETE"
         ]
       },
+      "eventType": {
+        "anyOf": [
+          {
+            "type": "string",
+            "enum": [
+              "ObjectEvent",
+              "AggregationEvent",
+              "AssociationEvent",
+              "TransformationEvent",
+              "TransactionEvent"
+            ]
+          },
+          {
+            "type": "string",
+            "format": "uri"
+          }
+        ]
+      },
       "persistentDisposition": {
         "allOf": [
           {
@@ -7398,9 +7416,6 @@
             "$ref": "#/components/schemas/uri"
           },
           "dataProcessingMethod": {
-            "$ref": "#/components/schemas/uri"
-          },
-          "bizRules": {
             "$ref": "#/components/schemas/uri"
           },
           "time": {


### PR DESCRIPTION
The changes in this pull request are to address internal inconsistencies noticed after ratification and publication, namely that `bizRules` is a valid field within `SensorMetadata` but not within `SensorReport`.  The changes in this pull request would bring the related artefacts into consistency with the published standard.

1. in event-definitions-JSON-Schema.json, `bizRules` was removed from within `SensorReport` (for consistency with the ratified published standard, the UML class diagram and the ontology). 
2. EPCIS-JSON-Schema.json was then regenerated using José's generate-inline-schema.sh script within JSON-Schema/ 
3. openapi.json was then regenerated using José's inject-schema.sh script within REST\ Bindings/schema-injector/